### PR TITLE
Fix use of usernameField and usernamePassword

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -69,7 +69,7 @@ module.exports = function(schema, options) {
 
         return new LocalStrategy({
             usernameField: options.usernameField,
-            passwordField: options.passwordField
+            passwordField: options.hashField
         }, function(username, password, cb) {
             self.findByUsername(username, function(err, user) {
                 if (err) { return cb(err); }


### PR DESCRIPTION
Fixes Passport not getting the specified usernameField in the plugin. This implies a change in how it's used with passport.

Before it was used like this:

``` javascript
passport.use(new LocalStrategy(User.authenticate()));
```

Now it's used like this:

``` javascript
passport.use(User.authenticate());
```

It's simplier and I don't think it's useful getting that object out of the plugin. The only 'problem' is the require added to the plugin, but well, this plugin also require passport to be present so it's affordable.
