### PR TITLE
Customising error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,7 @@ First you need to plugin Passport-Local Mongoose into your User schema
 You're free to define your User how you like. Passport-Local Mongoose will add a username, hash and salt field to store
 the username, the hashed password and the salt value.
 
-Additionally Passport-Local Mongoose adds these methods to your Schema.
-
-#### Instance methods
-* setPassword(password, cb) asynchronous method to set a user's password hash and salt
-* authenticate(password, cb) asynchronous method to authenticate a user instance
-
-#### Static methods
-* authenticate() Generates a function that is used in Passport's LocalStrategy
-* serializeUser() Generates a function that is used by Passport to serialize users into the session
-* deserializeUser() Generates a function that is used by Passport to deserialize users into the session
-* register(user, password, cb) Convenience method to register a new user instance with a given password. Checks if username is unique. See [login example](https://github.com/saintedlama/passport-local-mongoose/tree/master/examples/login).
-* findByUsername() Convenience method to find a user instance by it's unique username.
+Additionally Passport-Local Mongoose adds some methods to your Schema. See the API Documentation section for more details.
 
 ### Configure Passport/Passport-Local
 You should configure Passport/Passport-Local as described in [the Passport Guide](http://passportjs.org/guide/configure/).
@@ -60,6 +49,22 @@ To setup Passport-Local Mongoose use this code
     passport.deserializeUser(User.deserializeUser());
 
 Make sure that you have mongoose connected and you're done.
+
+#### Simplified Passport/Passport-Local Configuration
+Starting with version 0.2.1 passport-local-mongoose adds a helper method `createStrategy` as static method to your schema.
+The `createStrategy` is responsible to setup passport-local `LocalStrategy` with the correct options.
+
+    var User = require('./models/user');
+    
+    // CHANGE: USE "createStrategy" INSTEAD OF "authenticate"
+    passport.use(User.createStrategy()));
+    
+    passport.serializeUser(User.serializeUser());
+    passport.deserializeUser(User.deserializeUser());
+
+The reason for this functionality is that when using the `usernameField` option to specify an alternative usernameField name, 
+for example "email" passport-local would still expect your frontend login form to contain an input field with name "username"
+instead of email. This can be configured for passport-local but this is double the work. So we got this shortcut implemented.
 
 ### Options
 When plugging in Passport-Local Mongoose plugin additional options can be provided to configure
@@ -89,7 +94,19 @@ Passport-Local Mongoose use the pbkdf2 algorithm of the node crypto library.
 (in contrary to bcrypt). For every user a generated salt value is saved to make
 rainbow table attacks even harder.
 
-
 ### Examples
 For a complete example implementing a registration, login and logout see the 
 [login example](https://github.com/saintedlama/passport-local-mongoose/tree/master/examples/login).
+
+## API Documentation
+### Instance methods
+* setPassword(password, cb) asynchronous method to set a user's password hash and salt
+* authenticate(password, cb) asynchronous method to authenticate a user instance
+
+### Static methods
+* authenticate() Generates a function that is used in Passport's LocalStrategy
+* serializeUser() Generates a function that is used by Passport to serialize users into the session
+* deserializeUser() Generates a function that is used by Passport to deserialize users into the session
+* register(user, password, cb) Convenience method to register a new user instance with a given password. Checks if username is unique. See [login example](https://github.com/saintedlama/passport-local-mongoose/tree/master/examples/login).
+* findByUsername() Convenience method to find a user instance by it's unique username.
+* createStrategy() Creates a configured passport-local `LocalStrategy` instance that can be used in passport.

--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -1,7 +1,7 @@
 var util = require('util'),
-	crypto = require('crypto'),
+    crypto = require('crypto'),
     LocalStrategy = require('passport-local').Strategy,
-	BadRequestError = require('passport-local').BadRequestError;
+    BadRequestError = require('passport-local').BadRequestError;
 
 module.exports = function(schema, options) {
     options = options || {};
@@ -13,11 +13,11 @@ module.exports = function(schema, options) {
     options.usernameField = options.usernameField || 'username';
     options.hashField = options.hashField || 'hash';
     options.saltField = options.saltField || 'salt';
-	options.incorrectPasswordError = options.incorrectPasswordError || 'Incorrect password';
-	options.incorrectUsernameError = options.incorrectUsernameError || 'Incorrect username';
-	options.missingUsernameError = options.missingUsernameError || 'Field %s is not set';
-	options.missingPasswordError = options.missingPasswordError || 'Password argument not set!';
-	options.userExistsError = options.userExistsError || 'User already exists with name %s';
+    options.incorrectPasswordError = options.incorrectPasswordError || 'Incorrect password';
+    options.incorrectUsernameError = options.incorrectUsernameError || 'Incorrect username';
+    options.missingUsernameError = options.missingUsernameError || 'Field %s is not set';
+    options.missingPasswordError = options.missingPasswordError || 'Password argument not set!';
+    options.userExistsError = options.userExistsError || 'User already exists with name %s';
 
     var schemaFields = {};
     schemaFields[options.usernameField] = String;


### PR DESCRIPTION
Added the ability to customise each of the error messages thrown from the plugin. This was necessary to support multiple languages.

It shouldn't break any existing projects because all of the defaults still remain.
