### PR TITLE
Optionally convert username to lowercase before find

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -11,6 +11,10 @@ module.exports = function(schema, options) {
     
     // Populate field names with defaults if not set
     options.usernameField = options.usernameField || 'username';
+    
+    // option to convert username to lowercase when finding
+    options.usernameLowerCase = options.usernameLowerCase || false;
+    
     options.hashField = options.hashField || 'hash';
     options.saltField = options.saltField || 'salt';
     options.incorrectPasswordError = options.incorrectPasswordError || 'Incorrect password';
@@ -140,6 +144,12 @@ module.exports = function(schema, options) {
 
     schema.statics.findByUsername = function(username, cb) {
         var queryParameters = {};
+        
+        // if specified, convert the username to lowercase
+        if (options.usernameLowerCase) {
+            username = username.toLowerCase();
+        }
+        
         queryParameters[options.usernameField] = username;
         
         var query = this.findOne(queryParameters);


### PR DESCRIPTION
Given that:
- I am using email addresses for usernames
- email addresses are generally case-insensitive (or converted to upper/lower case)
- I use the lowercase option on my schema to convert usernames
- I want my users to be able to neurotically mix upper and lowercase letters in their email addresses when logging in

I have made these changes:
- created `options.usernameLowerCase` which defaults to `false`
- if `options.usernameLowerCase` is `true`, convert username to lowercase in `schema.statics.findByUsername`.
