### PR TITLE
Don't throw an error if the user has no username set.

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -155,7 +155,7 @@ module.exports = function(schema, options) {
         var queryParameters = {};
         
         // if specified, convert the username to lowercase
-        if (options.usernameLowerCase) {
+        if (options.usernameLowerCase && !(username === void 0)) {
             username = username.toLowerCase();
         }
         


### PR DESCRIPTION
If the User object with a custom username gets saved, but no username is set an exception is thrown.
This changes checks first if username is not undefined before it calls the toLowerCase method.
