### PR TITLE
Allows options to be passed into setPassword and authenticate methods

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -5,10 +5,10 @@ var BadRequestError = require('./badrequesterror');
 
 module.exports = function(schema, options) {
     options = options || {};
-    schema.options.saltlen = options.saltlen || 32;
-    schema.options.iterations = options.iterations || 25000;
-    schema.options.keylen = options.keylen || 512;
-    schema.options.encoding = options.encoding || 'hex';
+    options.saltlen = options.saltlen || 32;
+    options.iterations = options.iterations || 25000;
+    options.keylen = options.keylen || 512;
+    options.encoding = options.encoding || 'hex';
 
     // Populate field names with defaults if not set
     options.usernameField = options.usernameField || 'username';
@@ -44,26 +44,36 @@ module.exports = function(schema, options) {
         next();
     });
 
-    schema.methods.setPassword = function (password, cb) {
+    schema.methods.setPassword = function (password, opts, cb) {
+        if (typeof(opts) === 'function') {
+            cb = opts;
+            opts = {};
+        }
+
+        opts.saltlen = opts.saltlen || options.saltlen;
+        opts.iterations = opts.iterations || options.iterations;
+        opts.keylen = opts.keylen || options.keylen;
+        opts.encoding = opts.encoding || options.encoding;
+
         if (!password) {
             return cb(new BadRequestError(options.missingPasswordError));
         }
 
         var self = this;
 
-        crypto.randomBytes(this.schema.options.saltlen, function(err, buf) {
+        crypto.randomBytes(opts.saltlen, function(err, buf) {
             if (err) {
                 return cb(err);
             }
 
-            var salt = buf.toString(self.schema.options.encoding);
+            var salt = buf.toString(opts.encoding);
 
-            crypto.pbkdf2(password, salt, self.schema.options.iterations, self.schema.options.keylen, function(err, hashRaw) {
+            crypto.pbkdf2(password, salt, opts.iterations, opts.keylen, function(err, hashRaw) {
                 if (err) {
                     return cb(err);
                 }
 
-                self.set(options.hashField, new Buffer(hashRaw, 'binary').toString(self.schema.options.encoding));
+                self.set(options.hashField, new Buffer(hashRaw, 'binary').toString(opts.encoding));
                 self.set(options.saltField, salt);
 
                 cb(null, self);
@@ -71,20 +81,29 @@ module.exports = function(schema, options) {
         });
     };
 
-    schema.methods.authenticate = function(password, cb) {
+    schema.methods.authenticate = function(password, opts, cb) {
+        if (typeof(opts) === 'function') {
+            cb = opts;
+            opts = {};
+        }
+
+        opts.saltlen = opts.saltlen || options.saltlen;
+        opts.iterations = opts.iterations || options.iterations;
+        opts.keylen = opts.keylen || options.keylen;
+        opts.encoding = opts.encoding || options.encoding;
+
         var self = this;
 
         if (!this.get(options.saltField)) {
             return cb(null, false, { message: options.noSaltValueStoredError });
         }
 
-        crypto.pbkdf2(password, this.get(options.saltField), this.schema.options.iterations,
-            this.schema.options.keylen, function(err, hashRaw) {
+        crypto.pbkdf2(password, this.get(options.saltField), opts.iterations, opts.keylen, function(err, hashRaw) {
             if (err) {
                 return cb(err);
             }
 
-            var hash = new Buffer(hashRaw, 'binary').toString(self.schema.options.encoding);
+            var hash = new Buffer(hashRaw, 'binary').toString(opts.encoding);
 
             if (hash === self.get(options.hashField)) {
                 return cb(null, self);

--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -45,6 +45,7 @@ module.exports = function(schema, options) {
     });
 
     schema.methods.setPassword = function (password, opts, cb) {
+        opts = opts || {};
         if (typeof(opts) === 'function') {
             cb = opts;
             opts = {};
@@ -82,11 +83,12 @@ module.exports = function(schema, options) {
     };
 
     schema.methods.authenticate = function(password, opts, cb) {
+        opts = opts || {};
         if (typeof(opts) === 'function') {
             cb = opts;
             opts = {};
         }
-
+        
         opts.saltlen = opts.saltlen || options.saltlen;
         opts.iterations = opts.iterations || options.iterations;
         opts.keylen = opts.keylen || options.keylen;

--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -5,17 +5,17 @@ var BadRequestError = require('./badrequesterror');
 
 module.exports = function(schema, options) {
     options = options || {};
-    options.saltlen = options.saltlen || 32;
-    options.iterations = options.iterations || 25000;
-    options.keylen = options.keylen || 512;
-    options.encoding = options.encoding || 'hex';
+    schema.options.saltlen = options.saltlen || 32;
+    schema.options.iterations = options.iterations || 25000;
+    schema.options.keylen = options.keylen || 512;
+    schema.options.encoding = options.encoding || 'hex';
 
     // Populate field names with defaults if not set
     options.usernameField = options.usernameField || 'username';
-    
+
     // option to convert username to lowercase when finding
     options.usernameLowerCase = options.usernameLowerCase || false;
-    
+
     options.hashField = options.hashField || 'hash';
     options.saltField = options.saltField || 'salt';
 
@@ -28,7 +28,7 @@ module.exports = function(schema, options) {
 
     var schemaFields = {};
     if (!schema.path(options.usernameField)) {
-    	schemaFields[options.usernameField] = String;
+        schemaFields[options.usernameField] = String;
     }
     schemaFields[options.hashField] = String;
     schemaFields[options.saltField] = String;
@@ -48,22 +48,22 @@ module.exports = function(schema, options) {
         if (!password) {
             return cb(new BadRequestError(options.missingPasswordError));
         }
-        
+
         var self = this;
 
-        crypto.randomBytes(options.saltlen, function(err, buf) {
+        crypto.randomBytes(this.schema.options.saltlen, function(err, buf) {
             if (err) {
                 return cb(err);
             }
 
-            var salt = buf.toString(options.encoding);
+            var salt = buf.toString(self.schema.options.encoding);
 
-            crypto.pbkdf2(password, salt, options.iterations, options.keylen, function(err, hashRaw) {
+            crypto.pbkdf2(password, salt, self.schema.options.iterations, self.schema.options.keylen, function(err, hashRaw) {
                 if (err) {
                     return cb(err);
                 }
 
-                self.set(options.hashField, new Buffer(hashRaw, 'binary').toString(options.encoding));
+                self.set(options.hashField, new Buffer(hashRaw, 'binary').toString(self.schema.options.encoding));
                 self.set(options.saltField, salt);
 
                 cb(null, self);
@@ -78,12 +78,13 @@ module.exports = function(schema, options) {
             return cb(null, false, { message: options.noSaltValueStoredError });
         }
 
-        crypto.pbkdf2(password, this.get(options.saltField), options.iterations, options.keylen, function(err, hashRaw) {
+        crypto.pbkdf2(password, this.get(options.saltField), this.schema.options.iterations,
+            this.schema.options.keylen, function(err, hashRaw) {
             if (err) {
                 return cb(err);
             }
-            
-            var hash = new Buffer(hashRaw, 'binary').toString(options.encoding);
+
+            var hash = new Buffer(hashRaw, 'binary').toString(self.schema.options.encoding);
 
             if (hash === self.get(options.hashField)) {
                 return cb(null, self);
@@ -103,16 +104,16 @@ module.exports = function(schema, options) {
                 if (user) {
                     return user.authenticate(password, cb);
                 } else {
-                    return cb(null, false, { message: options.incorrectUsernameError })
+                    return cb(null, false, { message: options.incorrectUsernameError });
                 }
             });
-        }
+        };
     };
 
     schema.statics.serializeUser = function() {
         return function(user, cb) {
             cb(null, user.get(options.usernameField));
-        }
+        };
     };
 
     schema.statics.deserializeUser = function() {
@@ -120,9 +121,9 @@ module.exports = function(schema, options) {
 
         return function(username, cb) {
             self.findByUsername(username, cb);
-        }
+        };
     };
-    
+
     schema.statics.register = function(user, password, cb) {
         // Create an instance of this in case user isn't already an instance
         if (!(user instanceof this)) {
@@ -136,11 +137,11 @@ module.exports = function(schema, options) {
         var self = this;
         self.findByUsername(user.get(options.usernameField), function(err, existingUser) {
             if (err) { return cb(err); }
-            
+
             if (existingUser) {
                 return cb(new BadRequestError(util.format(options.userExistsError, user.get(options.usernameField))));
             }
-            
+
             user.setPassword(password, function(err, user) {
                 if (err) {
                     return cb(err);
@@ -159,14 +160,14 @@ module.exports = function(schema, options) {
 
     schema.statics.findByUsername = function(username, cb) {
         var queryParameters = {};
-        
+
         // if specified, convert the username to lowercase
         if (username !== undefined && options.usernameLowerCase) {
             username = username.toLowerCase();
         }
-        
+
         queryParameters[options.usernameField] = username;
-        
+
         var query = this.findOne(queryParameters);
         if (options.selectFields) {
             query.select(options.selectFields);

--- a/test/passport-local-mongoose.js
+++ b/test/passport-local-mongoose.js
@@ -258,6 +258,59 @@ describe('passportLocalMongoose', function () {
                 });
             });
         });
+
+        it('should allow changing of saltlen, keylen, and iterations via passed in options', function (done) {
+            this.timeout(5000); // Five seconds - mongo db access needed
+
+            var user = new DefaultUser({username : 'user'});
+            user.setPassword('password', {
+                saltlen: 64,
+                iterations: 5000,
+                keylen: 256
+            }, function (err) {
+                assert.ifError(err);
+
+                user.save(function (err) {
+                    assert.ifError(err);
+
+                    user.authenticate('password', {
+                        saltlen: 64,
+                        iterations: 5000,
+                        keylen: 256
+                    }, function (err, result, options) {
+                        assert.ifError(err);
+                        assert.ok(result);
+
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('should use default saltlen, iterations, keylen, encoding, if no options passed in', function (done) {
+            this.timeout(5000); // Five seconds - mongo db access needed
+
+            var user = new DefaultUser({username : 'user'});
+            user.setPassword('password', {
+                saltlen: 64,
+                iterations: 5000,
+                keylen: 256
+            }, function (err) {
+                assert.ifError(err);
+
+                user.save(function (err) {
+                    assert.ifError(err);
+
+                    user.authenticate('password', function (err, result, options) {
+                        assert.ifError(err);
+                        assert.equal(result, false);
+                        assert.ok(options.message);
+
+                        done();
+                    });
+                });
+            });
+        });
     });
 
 
@@ -375,7 +428,7 @@ describe('passportLocalMongoose', function () {
             user.save(function (err) {
                 assert.ifError(err);
 
-                var query = User.findByUsername('hugo')
+                var query = User.findByUsername('hugo');
 
                 assert.ok(query);
 
@@ -549,7 +602,7 @@ describe('passportLocalMongoose', function () {
                 });
             });
         });
-        
+
         it('it should add username existing user without username', function (done) {
             this.timeout(5000); // Five seconds - mongo db access needed
 


### PR DESCRIPTION
Added the saltlen, iterations, keylen, and encoding options directly
onto the schema options to allow a developer to update a users
salt/key/iterations value after the user has already created a
password. The developer can check the document version and if its an
old version, authentic using the old salt/keylen/iterations/encode and
once authenticated, then switch to the new values and set the password
and update the document version number. All tests passing.
