### PR TITLE
An improvement to case insensitive logins?

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -8,23 +8,43 @@ module.exports = function(schema, options) {
     options.saltlen = options.saltlen || 32;
     options.iterations = options.iterations || 25000;
     options.keylen = options.keylen || 512;
-    
+    options.encoding = options.encoding || 'hex';
+
     // Populate field names with defaults if not set
     options.usernameField = options.usernameField || 'username';
+    
+    // option to convert username to lowercase when finding
+    options.usernameLowerCase = options.usernameLowerCase || false;
+
+    options.caseInsensitiveUsername = options.caseInsensitiveUsername || false;
+    
     options.hashField = options.hashField || 'hash';
     options.saltField = options.saltField || 'salt';
+
     options.incorrectPasswordError = options.incorrectPasswordError || 'Incorrect password';
     options.incorrectUsernameError = options.incorrectUsernameError || 'Incorrect username';
     options.missingUsernameError = options.missingUsernameError || 'Field %s is not set';
     options.missingPasswordError = options.missingPasswordError || 'Password argument not set!';
     options.userExistsError = options.userExistsError || 'User already exists with name %s';
+    options.noSaltValueStoredError = options.noSaltValueStoredError || 'Authentication not possible. No salt value stored in mongodb collection!';
 
     var schemaFields = {};
-    schemaFields[options.usernameField] = String;
+    if (!schema.path(options.usernameField)) {
+    	schemaFields[options.usernameField] = String;
+    }
     schemaFields[options.hashField] = String;
     schemaFields[options.saltField] = String;
 
     schema.add(schemaFields);
+
+    schema.pre('save', function(next) {
+        // if specified, convert the username to lowercase
+        if (options.usernameLowerCase) {
+            this[options.usernameField] = this[options.usernameField].toLowerCase();
+        }
+
+        next();
+    });
 
     schema.methods.setPassword = function (password, cb) {
         if (!password) {
@@ -38,14 +58,14 @@ module.exports = function(schema, options) {
                 return cb(err);
             }
 
-            var salt = buf.toString('hex');
+            var salt = buf.toString(options.encoding);
 
             crypto.pbkdf2(password, salt, options.iterations, options.keylen, function(err, hashRaw) {
                 if (err) {
                     return cb(err);
                 }
 
-                self.set(options.hashField, new Buffer(hashRaw, 'binary').toString('hex'));
+                self.set(options.hashField, new Buffer(hashRaw, 'binary').toString(options.encoding));
                 self.set(options.saltField, salt);
 
                 cb(null, self);
@@ -56,13 +76,16 @@ module.exports = function(schema, options) {
     schema.methods.authenticate = function(password, cb) {
         var self = this;
 
-        // TODO: Fix callback and behavior to match passport
+        if (!this.get(options.saltField)) {
+            return cb(null, false, { message: options.noSaltValueStoredError });
+        }
+
         crypto.pbkdf2(password, this.get(options.saltField), options.iterations, options.keylen, function(err, hashRaw) {
             if (err) {
                 return cb(err);
             }
             
-            var hash = new Buffer(hashRaw, 'binary').toString('hex');
+            var hash = new Buffer(hashRaw, 'binary').toString(options.encoding);
 
             if (hash === self.get(options.hashField)) {
                 return cb(null, self);
@@ -138,6 +161,16 @@ module.exports = function(schema, options) {
 
     schema.statics.findByUsername = function(username, cb) {
         var queryParameters = {};
+        
+        // if specified, convert the username to lowercase
+        if (username !== undefined && options.usernameLowerCase) {
+            username = username.toLowerCase();
+        }
+
+        if (typeof username !== 'undefined' && options.caseInsensitiveUsername){
+            username = new RegExp(username, 'i');
+        }
+        
         queryParameters[options.usernameField] = username;
         
         var query = this.findOne(queryParameters);
@@ -145,7 +178,15 @@ module.exports = function(schema, options) {
             query.select(options.selectFields);
         }
 
-        query.exec(cb);
+        if (options.populateFields) {
+            query.populate(options.populateFields);
+        }
+
+        if (cb) {
+            query.exec(cb);
+        } else {
+            return query;
+        }
     };
 
     schema.statics.createStrategy = function() {


### PR DESCRIPTION
I'm using this library in a few of my projects and it works great I appreacitate it. 

I ran into a minor problem with it though, a client mentioned they wanted the logins to be case 
insensitive because some of the users have weirdly capitalized usernames like xxxGunzAndRosezxx and sometimes I guess they forget how they capitalized it. 

Anyway, I noticed that the current implementation of case insensitive logins does .toLower on the username before saving it which is isn't great because the user loses their fancy capitalization in places where the username is shown. I could have stored a separate username field, but instead I opted to change the library to use a regex to search for the username as seen in this PR.

If you'd prefer this solution let me know and I can clean it up and resubmit it. 