### PR TITLE
Brute force interval made less aggressive; maxInterval defined

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -88,11 +88,15 @@ module.exports = function(schema, options) {
     schema.methods.authenticate = function(password, cb) {
         var self = this;
 
-        if (options.limitAttempts && (Date.now() - this.get(options.lastLoginField) < Math.pow(options.interval, this.get(options.attemptsField) + 1))){
-            // This login attempt is too soon after the previous attempt
+        if (options.limitAttempts) {
+          var calculatedInterval = Math.pow(options.interval, Math.log(this.get(options.attemptsField) + 1));
+
+          if (Date.now() - this.get(options.lastLoginField) < calculatedInterval) {
             this.set(options.lastLoginField, Date.now());
-            self.save();
+            this.save();
             return cb(null, false, { message: options.attemptTooSoonError });
+          }
+
         }
 
         if (!this.get(options.saltField)) {

--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -24,6 +24,7 @@ module.exports = function(schema, options) {
       options.lastLoginField = options.lastLoginField || 'last';
       options.attemptsField = options.attemptsField || 'attempts';
       options.interval = options.interval || 100; // 100 ms
+      options.maxInterval = options.maxInterval || 300000; // 5 min
     }
 
     options.incorrectPasswordError = options.incorrectPasswordError || 'Incorrect password';
@@ -89,7 +90,8 @@ module.exports = function(schema, options) {
         var self = this;
 
         if (options.limitAttempts) {
-          var calculatedInterval = Math.pow(options.interval, Math.log(this.get(options.attemptsField) + 1));
+          var attemptsInterval = Math.pow(options.interval, Math.log(this.get(options.attemptsField) + 1));
+          var calculatedInterval = (attemptsInterval < options.maxInterval) ? attemptsInterval : options.maxInterval; 
 
           if (Date.now() - this.get(options.lastLoginField) < calculatedInterval) {
             this.set(options.lastLoginField, Date.now());

--- a/test/passport-local-mongoose.js
+++ b/test/passport-local-mongoose.js
@@ -306,7 +306,7 @@ describe('passportLocalMongoose', function () {
             this.timeout(5000); // Five seconds - mongo db access needed
 
             var UserSchema = new Schema({});
-            UserSchema.plugin(passportLocalMongoose, { limitAttempts : true, interval : 2000 }); // One second to be on the save side to trigger this test case!
+            UserSchema.plugin(passportLocalMongoose, { limitAttempts : true, interval : 10000 }); // High initial value for test
 
             var User = mongoose.model('LockUserAfterLimitAttempts', UserSchema);
 
@@ -331,6 +331,7 @@ describe('passportLocalMongoose', function () {
 
                                 // Last login attempt should lock the user!
                                 User.authenticate()('user', 'password', function (err, result, message) {
+                                  debugger;
                                     expect(err).to.not.exist;
                                     expect(result).to.be.false;
                                     

--- a/test/passport-local-mongoose.js
+++ b/test/passport-local-mongoose.js
@@ -302,11 +302,11 @@ describe('passportLocalMongoose', function () {
             });
         });
 
-        it.only('should lock authenticate after too many login attempts', function (done) {
+        it('should lock authenticate after too many login attempts', function (done) {
             this.timeout(5000); // Five seconds - mongo db access needed
 
             var UserSchema = new Schema({});
-            UserSchema.plugin(passportLocalMongoose, { limitAttempts : true, interval : 10000 }); // High initial value for test
+            UserSchema.plugin(passportLocalMongoose, { limitAttempts : true, interval : 20000 }); // High initial value for test
 
             var User = mongoose.model('LockUserAfterLimitAttempts', UserSchema);
 


### PR DESCRIPTION
The interval between logins for the brute force protection increased exponentially for each failed attempt.

With default interval of 100: 

| failures | before | after |
|----------|--------|------|
|0          |100 ms.        | 1 ms.     |
|1          |10 seconds.  | 24 ms.  |
|2          |16.7 minutes | 157ms. |
|3           |27.7 hours   |592 ms.  | 
|10       | 3.17 million years | 40 seconds | 

A maxInterval is also added. This is helpful for when an account is locked out the user can be told to wait for a known amount of time before trying again. The default maxInterval is set to five minutes. 