### PR TITLE
checking for username field before trying to convert it toLowerCase

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -52,7 +52,7 @@ module.exports = function(schema, options) {
 
     schema.pre('save', function(next) {
         // if specified, convert the username to lowercase
-        if (options.usernameLowerCase) {
+        if (options.usernameLowerCase && this[options.usernameField]) {
             this[options.usernameField] = this[options.usernameField].toLowerCase();
         }
 
@@ -91,7 +91,7 @@ module.exports = function(schema, options) {
 
         if (options.limitAttempts) {
           var attemptsInterval = Math.pow(options.interval, Math.log(this.get(options.attemptsField) + 1));
-          var calculatedInterval = (attemptsInterval < options.maxInterval) ? attemptsInterval : options.maxInterval; 
+          var calculatedInterval = (attemptsInterval < options.maxInterval) ? attemptsInterval : options.maxInterval;
 
           if (Date.now() - this.get(options.lastLoginField) < calculatedInterval) {
             this.set(options.lastLoginField, Date.now());


### PR DESCRIPTION
Fixes: #63 

There are uses-cases where the username field is not set when the document is first created. In these cases toLowerCase would result in `Uncaught TypeError: Cannot call method 'toLowerCase' of undefined`. This is a defensive fix.