### PR TITLE
Use scmp to securely compare passwords.

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -2,6 +2,7 @@ var util = require('util');
 var crypto = require('crypto');
 var LocalStrategy = require('passport-local').Strategy;
 var BadRequestError = require('./badrequesterror');
+var scmp = require('scmp');
 
 module.exports = function(schema, options) {
     options = options || {};
@@ -112,7 +113,7 @@ module.exports = function(schema, options) {
 
             var hash = new Buffer(hashRaw, 'binary').toString(options.encoding);
 
-            if (hash === self.get(options.hashField)) {
+            if (scmp(hash, self.get(options.hashField))) {
                 if (options.limitAttempts){
                   self.set(options.lastLoginField, Date.now());
                   self.set(options.attemptsField, 0);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "node": ">= 0.9"
   },
   "dependencies": {
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "scmp": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^1.10.0",


### PR DESCRIPTION
This resolves issue #70 by using the [scmp](https://www.npmjs.com/package/scmp) package which implements string comparison in constant-time.