### PR TITLE
Do not expose hash and salt fields by default ({select: false})

### DIFF
--- a/lib/passport-local-mongoose.js
+++ b/lib/passport-local-mongoose.js
@@ -53,8 +53,8 @@ module.exports = function(schema, options) {
     if (!schema.path(options.usernameField)) {
         schemaFields[options.usernameField] = { type : String, unique : options.usernameUnique };
     }
-    schemaFields[options.hashField] = String;
-    schemaFields[options.saltField] = String;
+    schemaFields[options.hashField] = {type: String, select: false};
+    schemaFields[options.saltField] = {type: String, select: false};
 
     if (options.limitAttempts){
       schemaFields[options.attemptsField] = {type: Number, default: 0};
@@ -166,7 +166,7 @@ module.exports = function(schema, options) {
         var self = this;
 
         return function(username, password, cb) {
-            self.findByUsername(username, function(err, user) {
+            self.findByUsername(username, true, function(err, user) {
                 if (err) { return cb(err); }
 
                 if (user) {
@@ -226,8 +226,12 @@ module.exports = function(schema, options) {
         });
     };
 
-    schema.statics.findByUsername = function(username, cb) {
+    schema.statics.findByUsername = function(username, selectHashSaltFields, cb) {
         var queryParameters = {};
+        if (typeof cb === 'undefined') {
+          cb = selectHashSaltFields;
+          selectHashSaltFields = false;
+        }
 
         // if specified, convert the username to lowercase
         if (username !== undefined && options.usernameLowerCase) {
@@ -237,6 +241,11 @@ module.exports = function(schema, options) {
         queryParameters[options.usernameField] = username;
 
         var query = this.findOne(queryParameters);
+
+        if (selectHashSaltFields) {
+            query.select('+' + options.hashField + " +" + options.saltField);
+        }
+
         if (options.selectFields) {
             query.select(options.selectFields);
         }

--- a/test/issues.js
+++ b/test/issues.js
@@ -79,12 +79,10 @@ describe('issues', function () {
 
                 var authenticate = User.authenticate();
 
-                authenticate('hugo', 'password', function(err, auth, reason) {
+                authenticate('hugo', 'password', function(err, result) {
                     assert.ifError(err);
-                    assert.equal(false, auth);
-                    assert.ok(reason);
 
-                    assert.equal('Authentication not possible. No salt value stored in mongodb collection!', reason.message);
+                    assert.ok(result instanceof User);
 
                     done();
                 });
@@ -147,6 +145,28 @@ describe('issues', function () {
         User.register({username: "nicolascage"}, 'password', function (err, user) {
             assert.equal(err, "My nasty error");
             done();
+        });
+    });
+
+    it('should not expose hash and salt fields - Issue #72', function(done) {
+        this.timeout(5000); // Five seconds - mongo db access needed
+
+        var UserSchema = new Schema({});
+
+        UserSchema.plugin(passportLocalMongoose, { });
+        var User = mongoose.model('ShouldNotExposeHashAndSaltFields_Issue_72', UserSchema);
+
+        User.register({username: "nicolascage"}, 'password', function (err, user) {
+            assert.ifError(err);
+            assert.ok(user);
+            User.findOne({username: "nicolascage"}, function(err, user) {
+                assert.ifError(err);
+                assert.ok(user);
+                assert.equal(user.username, "nicolascage");
+                assert.strictEqual(user.hash, undefined);
+                assert.strictEqual(user.salt, undefined);
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
This patch fixes #72 

As a side effect, when you don't have hash or salt in your `selectFields` (`{ selectFields : 'name' }` for example) it's now still possible to authenticate. Tests updated accordingly.

Why set `{select: false}` on both hash and salt fields? Because we don't want those fields in `populate`s and other `User.` query methods. And we want to be sure that we are not leaking hashes/passwords, thus it's not an option to apply `.select('-hash -salt')` every time we query/populate the `User` model.

If you ever want to access hash or salt outside the passport-local-mongoose module you still can perform `.select('+hash +salt')` on your query. 
