### PR TITLE
Prevent reuse of passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ field to hold the username for example "email".
 * maxAttempts: specifies the maximum number of failed attempts allowed before preventing login. Default: Infinity.
 * passwordValidator: specifies your custom validation function for the password in the form 'function(password,cb)'. Default: validates non-empty passwords.
 * usernameQueryFields: specifies alternative fields of the model for identifying a user (e.g. email).
+* preventReuse: specifies how many old hash/salt to keep around. if set to a positive integer, prevent reuse of passwords for that many successive password changes. Default: 0.
+* historyField: specifies the field name that holds the back history of hash/salt pairs. Defaults to 'passHistory'.
 
 *Attention!* Changing any of the hashing options (saltlen, iterations or keylen) in a production environment will prevent that existing users to authenticate!
 
@@ -124,7 +126,8 @@ Override default error messages by setting options.errorMessages.
 * IncorrectUsernameError 'Password or username are incorrect'
 * MissingUsernameError 'No username was given'
 * UserExistsError 'A user with the given username is already registered'
-  
+* PasswordReuseError 'Password reuse detected'
+
 ### Hash Algorithm
 Passport-Local Mongoose use the pbkdf2 algorithm of the node crypto library. 
 [Pbkdf2](http://en.wikipedia.org/wiki/PBKDF2) was chosen because platform independent
@@ -168,6 +171,7 @@ To commit the changed document, remember to use Mongoose's `document.save()` aft
 * `NoSaltValueStored`: Occurs in case no salt value is stored in the MongoDB collection.
 * `AttemptTooSoonError`: Occurs if the option `limitAttempts` is set to true and a login attept occures while the user is still penalized.
 * `TooManyAttemptsError`: Returned when the user's account is locked due to too many failed login attempts.
+* `PasswordReuseError`: Occurs when the `preventReuse` option is enabled and the password is being set to a previously used value.
 
 All those errors inherit from `AuthenticationError`, if you need a more general error class for checking.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ field to hold the username for example "email".
 * maxAttempts: specifies the maximum number of failed attempts allowed before preventing login. Default: Infinity.
 * passwordValidator: specifies your custom validation function for the password in the form 'function(password,cb)'. Default: validates non-empty passwords.
 * usernameQueryFields: specifies alternative fields of the model for identifying a user (e.g. email).
-* preventReuse: specifies how many old hash/salt to keep around. if set to a positive integer, prevent reuse of passwords for that many successive password changes. Default: 0.
+* preventReuse: specifies how many old hash/salt pairs to keep around. If set to a positive integer, prevent reuse of passwords for that many successive password changes. Default: 0.
 * historyField: specifies the field name that holds the back history of hash/salt pairs. Defaults to 'passHistory'.
 
 *Attention!* Changing any of the hashing options (saltlen, iterations or keylen) in a production environment will prevent that existing users to authenticate!

--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ module.exports = function(schema, options) {
   options.digestAlgorithm = options.digestAlgorithm || 'sha256'; // To get a list of supported hashes use crypto.getHashes()
   options.passwordValidator = options.passwordValidator || function(password, cb) { cb(null); };
 
+  // decline new passwords if they have been already used, looking back up to n times
+  options.preventReuse = options.preventReuse || 0;
+
   // Populate field names with defaults if not set
   options.usernameField = options.usernameField || 'username';
   options.usernameUnique = options.usernameUnique === undefined ? true : options.usernameUnique;
@@ -41,6 +44,10 @@ module.exports = function(schema, options) {
     options.maxAttempts = options.maxAttempts || Infinity;
   }
 
+  if (options.preventReuse) {
+    options.historyField = options.historyField || 'passHistory';
+  }
+
   options.errorMessages = options.errorMessages || {};
   options.errorMessages.MissingPasswordError = options.errorMessages.MissingPasswordError || 'No password was given';
   options.errorMessages.AttemptTooSoonError = options.errorMessages.AttemptTooSoonError || 'Account is currently locked. Try again later';
@@ -50,6 +57,7 @@ module.exports = function(schema, options) {
   options.errorMessages.IncorrectUsernameError = options.errorMessages.IncorrectUsernameError || 'Password or username are incorrect';
   options.errorMessages.MissingUsernameError = options.errorMessages.MissingUsernameError|| 'No username was given';
   options.errorMessages.UserExistsError = options.errorMessages.UserExistsError|| 'A user with the given username is already registered';
+  options.errorMessages.PasswordReuseError = options.errorMessages.PasswordReuseError|| 'Password reuse detected';
 
   var pbkdf2 = function(password, salt, callback) {
     if (pbkdf2DigestSupport) {
@@ -70,6 +78,10 @@ module.exports = function(schema, options) {
   if (options.limitAttempts) {
     schemaFields[options.attemptsField] = {type: Number, default: 0};
     schemaFields[options.lastLoginField] = {type: Date, default: Date.now};
+  }
+
+  if (options.preventReuse) {
+    schemaFields[options.historyField] = {type: Array, default: []};
   }
 
   schema.add(schemaFields);
@@ -105,6 +117,13 @@ module.exports = function(schema, options) {
         pbkdf2(password, salt, function(pbkdf2Err, hashRaw) {
           if (pbkdf2Err) {
             return cb(pbkdf2Err);
+          }
+
+          var oldHash = self.get(options.hashField);
+          if (options.preventReuse && oldHash) { // store the old values
+            var history = self.get(options.historyField) || [];
+            history.unshift([oldHash, self.get(options.saltField)]);
+            self.set( options.historyField, history.slice(0, options.preventReuse));
           }
 
           self.set(options.hashField, new Buffer(hashRaw, 'binary').toString(options.encoding));

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -11,5 +11,6 @@ module.exports = {
   UserExistsError : generaterr('UserExistsError', null,{ inherits : AuthenticationError }),
   NoSaltValueStoredError : generaterr('NoSaltValueStoredError', null,{ inherits : AuthenticationError }),
   AttemptTooSoonError : generaterr('AttemptTooSoonError', null,{ inherits : AuthenticationError }),
-  TooManyAttemptsError : generaterr('TooManyAttemptsError', null,{ inherits : AuthenticationError })
+  TooManyAttemptsError : generaterr('TooManyAttemptsError', null,{ inherits : AuthenticationError }),
+  PasswordReuseError : generaterr('PasswordReuseError', null,{ inherits : AuthenticationError })
 };

--- a/test/prevent-reuse.js
+++ b/test/prevent-reuse.js
@@ -8,8 +8,45 @@ describe('prevent password reuse', function() {
   beforeEach(mongotest.prepareDb('mongodb://localhost/passportlocalmongoosereuse'));
   afterEach(mongotest.disconnect());
 
-  it('should run my additional test', function () {
-    expect(true).to.be.true;
+  it('should add a configurable history field', function () {
+      var UserSchema = new Schema({});
+      UserSchema.plugin(passportLocalMongoose, {preventReuse: 1, historyField: 'myHistory'});
+      var User = mongoose.model('PreventReuseConfigurableField', UserSchema);
+      var user = new User();
+      expect(user.get('myHistory')).to.be.instanceof(Array);
+  });
+
+  it('should save old hash/salt pairs', function (done) {
+      this.timeout(5000); // Five seconds - heavy crypto in background
+
+      var UserSchema = new Schema({});
+      UserSchema.plugin(passportLocalMongoose, {preventReuse: 2});
+      var User = mongoose.model('PreventReuseSavesOld', UserSchema);
+
+      User.register({username: 'adrien'}, 'password', function(err, user) {
+        expect(user.passHistory.length).to.equal(0);
+
+        var firstHash = user.get('hash'), firstSalt = user.get('salt');
+
+        user.setPassword('password2', function (err2, user2) {
+          expect(user.passHistory.length).to.equal(1);
+          expect(user2.passHistory[0][0]).to.equal(firstHash);
+          expect(user2.passHistory[0][1]).to.equal(firstSalt);
+
+          user.setPassword('password3', function (err3, user3) {
+            expect(user.passHistory.length).to.equal(2);
+            expect(user.passHistory[1][0]).to.equal(firstHash);
+            expect(user.passHistory[1][1]).to.equal(firstSalt);
+
+            user.setPassword('password4', function (err4, user4) {
+              expect(user.passHistory.length).to.equal(2); // still just 2
+              done();
+            });
+          });
+        });
+
+      });
+
   });
 
 });

--- a/test/prevent-reuse.js
+++ b/test/prevent-reuse.js
@@ -1,0 +1,15 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+var expect = require('chai').expect;
+var passportLocalMongoose = require('../');
+var mongotest = require('./helpers/mongotest');
+
+describe('prevent password reuse', function() {
+  beforeEach(mongotest.prepareDb('mongodb://localhost/passportlocalmongoosereuse'));
+  afterEach(mongotest.disconnect());
+
+  it('should run my additional test', function () {
+    expect(true).to.be.true;
+  });
+
+});


### PR DESCRIPTION
This PR adds a new opt-in feature: _preventing users from reusing passwords_ up to `options.preventReuse` times. This is achieved by storing old hash/salt pairs in the `options.historyField` array, and checking against them when calling `setPassword()`.
