### PR TITLE
Added a check password function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Passport-Local Mongoose
-Passport-Local Mongoose is a [Mongoose](http://mongoosejs.com/) [plugin](http://mongoosejs.com/docs/plugins.html) 
+Passport-Local Mongoose is a [Mongoose](http://mongoosejs.com/) [plugin](http://mongoosejs.com/docs/plugins.html)
 that simplifies building username and password login with [Passport](http://passportjs.org).
 
 [![Build Status](https://travis-ci.org/saintedlama/passport-local-mongoose.png?branch=master)](https://travis-ci.org/saintedlama/passport-local-mongoose)
@@ -24,7 +24,7 @@ In case you need to install the whole set of dependencies
 ### Updating from 1.x to 2.x
 The default digest algorithm was changed due to security implications from **sha1** to **sha256**. If you decide
 to upgrade a production system from 1.x to 2.x your users **will not be able to login** since the digest
-algorithm was changed! In these cases plan some migration strategy and/or use the **sha1** option for the 
+algorithm was changed! In these cases plan some migration strategy and/or use the **sha1** option for the
 digest algorithm.
 
 ## Usage
@@ -35,11 +35,11 @@ First you need to plugin Passport-Local Mongoose into your User schema
     var mongoose = require('mongoose'),
         Schema = mongoose.Schema,
         passportLocalMongoose = require('passport-local-mongoose');
-    
+
     var User = new Schema({});
-    
+
     User.plugin(passportLocalMongoose);
-    
+
     module.exports = mongoose.model('User', User);
 
 You're free to define your User how you like. Passport-Local Mongoose will add a username, hash and salt field to store
@@ -56,10 +56,10 @@ To setup Passport-Local Mongoose use this code
 
     // requires the model with Passport-Local Mongoose plugged in
     var User = require('./models/user');
-    
+
     // use static authenticate method of model in LocalStrategy
     passport.use(new LocalStrategy(User.authenticate()));
-    
+
     // use static serialize and deserialize of model for passport session support
     passport.serializeUser(User.serializeUser());
     passport.deserializeUser(User.deserializeUser());
@@ -71,14 +71,14 @@ Starting with version 0.2.1 passport-local-mongoose adds a helper method `create
 The `createStrategy` is responsible to setup passport-local `LocalStrategy` with the correct options.
 
     var User = require('./models/user');
-    
+
     // CHANGE: USE "createStrategy" INSTEAD OF "authenticate"
     passport.use(User.createStrategy());
-    
+
     passport.serializeUser(User.serializeUser());
     passport.deserializeUser(User.deserializeUser());
 
-The reason for this functionality is that when using the `usernameField` option to specify an alternative usernameField name, 
+The reason for this functionality is that when using the `usernameField` option to specify an alternative usernameField name,
 for example "email" passport-local would still expect your frontend login form to contain an input field with name "username"
 instead of email. This can be configured for passport-local but this is double the work. So we got this shortcut implemented.
 
@@ -95,7 +95,7 @@ __Main Options__
 * keylen: specifies the length in byte of the generated key. Default: 512
 * digestAlgorithm: specifies the pbkdf2 digest algorithm. Default: sha256. (get a list of supported algorithms with crypto.getHashes())
 * interval: specifies the interval in milliseconds between login attempts. Default: 100
-* usernameField: specifies the field name that holds the username. Defaults to 'username'. This option can be used if you want to use a different 
+* usernameField: specifies the field name that holds the username. Defaults to 'username'. This option can be used if you want to use a different
 field to hold the username for example "email".
 * usernameUnique : specifies if the username field should be enforced to be unique by a mongodb index or not. Defaults to true.
 * saltField: specifies the field name that holds the salt value. Defaults to 'salt'.
@@ -124,22 +124,25 @@ Override default error messages by setting options.errorMessages.
 * IncorrectUsernameError 'Password or username are incorrect'
 * MissingUsernameError 'No username was given'
 * UserExistsError 'A user with the given username is already registered'
-  
+
 ### Hash Algorithm
-Passport-Local Mongoose use the pbkdf2 algorithm of the node crypto library. 
+Passport-Local Mongoose use the pbkdf2 algorithm of the node crypto library.
 [Pbkdf2](http://en.wikipedia.org/wiki/PBKDF2) was chosen because platform independent
 (in contrary to bcrypt). For every user a generated salt value is saved to make
 rainbow table attacks even harder.
 
 ### Examples
-For a complete example implementing a registration, login and logout see the 
+For a complete example implementing a registration, login and logout see the
 [login example](https://github.com/saintedlama/passport-local-mongoose/tree/master/examples/login).
 
 ## API Documentation
 ### Instance methods
 
-#### setPassword(password, cb) 
+#### setPassword(password, cb)
 asynchronous method to set a user's password hash and salt
+
+#### checkPassword(string, cb)
+asynchronous method to check if the string matches the user's password
 
 #### authenticate(password, cb)
 asynchronous method to authenticate a user instance
@@ -151,7 +154,7 @@ asynchronous method to reset a user's number of failed password attempts (only d
 - err
   - null unless the hasing algorithm throws an error
 - thisModel
-  - the model getting authenticated *if* authentication was successful otherwise false
+  - the model getting authenticated *if* authentication or check was successful otherwise false
 - passwordErr
   - an instance of `AuthenticationError` describing the reason the password failed, else undefined.
 

--- a/index.js
+++ b/index.js
@@ -127,9 +127,9 @@ module.exports = function(schema, options) {
       var hash = new Buffer(hashRaw, 'binary').toString(options.encoding);
 
       if (scmp(hash, user.get(options.hashField))) {
-        return cb(null, true);
+        return cb(null, user);
       } else {
-        return cb(null, false);
+        return cb(null, false, new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError));
       }
     });
   }

--- a/index.js
+++ b/index.js
@@ -117,6 +117,8 @@ module.exports = function(schema, options) {
   };
 
   function checkPassword(user, password, cb) {
+    password = password || '';
+
     pbkdf2(password, user.get(options.saltField), function(err, hashRaw) {
       if (err) {
         return cb(err);

--- a/index.js
+++ b/index.js
@@ -116,6 +116,22 @@ module.exports = function(schema, options) {
     });
   };
 
+  function checkPassword(user, password, cb) {
+    pbkdf2(password, user.get(options.saltField), function(err, hashRaw) {
+      if (err) {
+        return cb(err);
+      }
+
+      var hash = new Buffer(hashRaw, 'binary').toString(options.encoding);
+
+      if (scmp(hash, user.get(options.hashField))) {
+        return cb(null, true);
+      } else {
+        return cb(null, false);
+      }
+    });
+  }
+
   function authenticate(user, password, cb) {
     if (options.limitAttempts) {
       var attemptsInterval = Math.pow(options.interval, Math.log(user.get(options.attemptsField) + 1));
@@ -136,14 +152,12 @@ module.exports = function(schema, options) {
       return cb(null, false, new errors.NoSaltValueStoredError(options.errorMessages.NoSaltValueStoredError));
     }
 
-    pbkdf2(password, user.get(options.saltField), function(err, hashRaw) {
+    checkPassword(user, password, function(err, passwordValid) {
       if (err) {
         return cb(err);
       }
 
-      var hash = new Buffer(hashRaw, 'binary').toString(options.encoding);
-
-      if (scmp(hash, user.get(options.hashField))) {
+      if (err, passwordValid) {
         if (options.limitAttempts) {
           user.set(options.lastLoginField, Date.now());
           user.set(options.attemptsField, 0);
@@ -167,7 +181,23 @@ module.exports = function(schema, options) {
         }
       }
     });
+  }
 
+  schema.methods.checkPassword = function(password, cb) {
+    var self = this;
+
+    if (!self.get(options.saltField)) {
+      self.constructor.findByUsername(self.get(options.usernameField), true, function(err, user) {
+        if (err) return cb(err);
+        if (user) {
+          return checkPassword(user, password, cb);
+        } else {
+          return cb(new errors.IncorrectUsernameError(options.errorMessages.IncorrectUsernameError));
+        }
+      });
+    } else {
+      return checkPassword(self, password, cb);
+    }
   }
 
   schema.methods.authenticate = function(password, cb) {

--- a/test/passport-local-mongoose.js
+++ b/test/passport-local-mongoose.js
@@ -171,6 +171,37 @@ describe('passportLocalMongoose', function() {
     });
   });
 
+  describe('#checkPassword()', function() {
+    it('should return an error if the password checked does not match the user\'s password.', function(done) {
+      var user = new DefaultUser();
+
+      user.setPassword('password', function(err) {
+        assert.ifError(err);
+
+        user.checkPassword('notpassword', function(err, result, options) {
+          assert.ifError(err);
+          assert.equal(result, false);
+          assert.ok(options.message);
+          done();
+        });
+      });
+    });
+
+    it('should return the user if the passwords match', function(done) {
+      var user = new DefaultUser();
+
+      user.setPassword('password', function(err) {
+        assert.ifError(err);
+
+        user.checkPassword('password', function(err, result) {
+          assert.ifError(err);
+          assert.equal(user, result);
+          done();
+        });
+      });
+    });
+  });
+
   describe('#authenticate()', function() {
     it('should yield false in case user cannot be authenticated', function(done) {
       this.timeout(5000); // Five seconds - heavy crypto in background


### PR DESCRIPTION
I have been using this change for months now and it seems to work well. Also this is just a useful feature to have because you can do things like have the user enter their existing password before making important account changes.

Basically all I did was strip out the existing password checking and put it into its own `checkPassword` function. Then added it as an instance method.

As part of this I had to change the `authenticate` function so that it called the new `checkPassword` function so all that logic is kept in the same place.

I added 2 tests for the new instance method. Those tests as well as all the existing tests pass.

Sorry about all the diffs on the README.md file. I think my editor automatically stripped out all the trailing whitespaces in the file.
