### PR TITLE
Hide hash and salt fields of user in register()

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,6 +210,10 @@ module.exports = function(schema, options) {
         user.save(function(saveErr) {
           if (saveErr) { return cb(saveErr); }
 
+          // hide hashField & saltField by default
+          user[options.hashField] = undefined;
+          user[options.saltField] = undefined;
+
           cb(null, user);
         });
       });

--- a/index.js
+++ b/index.js
@@ -211,8 +211,8 @@ module.exports = function(schema, options) {
           if (saveErr) { return cb(saveErr); }
 
           // hide hashField & saltField by default
-          user[options.hashField] = undefined;
-          user[options.saltField] = undefined;
+          user[options.hashField] = null;
+          user[options.saltField] = null;
 
           cb(null, user);
         });

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -37,8 +37,8 @@ module.exports = function authenticate(user, password, options, cb) {
       }
 
       // hide hashField & saltField by default
-      user[options.hashField] = undefined;
-      user[options.saltField] = undefined;
+      user[options.hashField] = null;
+      user[options.saltField] = null;
 
       return cb(null, user);
     } else {

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -35,6 +35,11 @@ module.exports = function authenticate(user, password, options, cb) {
         user.set(options.attemptsField, 0);
         user.save();
       }
+
+      // hide hashField & saltField by default
+      user[options.hashField] = undefined;
+      user[options.saltField] = undefined;
+
       return cb(null, user);
     } else {
       if (options.limitAttempts) {


### PR DESCRIPTION
Usually, in `register()` callback, you do not need salt and hash anymore. They should be hidden to avoid exposing to API.