### PR TITLE
Fixed vulnerable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node": ">= 0.12"
   },
   "dependencies": {
-    "debug": "^2.6.8",
+    "debug": "^3.1.0",
     "generaterr": "^1.5.0",
     "passport-local": "^1.0.0",
     "scmp": "^2.0.0",


### PR DESCRIPTION
The Debug module is vulnerable to [a ReDoS attack](https://nodesecurity.io/advisories/534). It was fixed in 2.6.9 and the 3.0 track. I went ahead and incremented to 3.1.0 since nothing breaks.