### PR TITLE
Correct a documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ we want to restrict the query to only query users with field `active` set to `tr
 
 ```javascript
 UserSchema.plugin(passportLocalMongoose, {
-  // Needed to set usernameUnique to true to avoid a mongodb index on the username column!
+  // Needed to set usernameUnique to false to avoid a mongodb index on the username column!
   usernameUnique: false,
 
   findByUsername: function(model, queryParameters) {


### PR DESCRIPTION
Obviously the comment should say `Needed to set usernameUnique to false to avoid a mongodb index on the username column!` instead of true to reflect the option value