### PR TITLE
Fix error thrown by User.changePassword() when the reason for failure is not an IncorrectPasswordError

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,9 +122,9 @@ module.exports = function(schema, options) {
         }
       })
       .then(() => this.authenticate(oldPassword))
-      .then(({ user }) => {
+      .then(({ user, error }) => {
         if (!user) {
-          throw new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError);
+          throw error;
         }
       })
       .then(() => this.setPassword(newPassword))


### PR DESCRIPTION
Fixes https://github.com/saintedlama/passport-local-mongoose/issues/255

Another reason would e.g. be an AttemptTooSoonError