### PR TITLE
Make debug package a development dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,6 +1684,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -3345,7 +3346,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "node": ">= 6.0.0"
   },
   "dependencies": {
-    "debug": "^3.1.0",
     "generaterr": "^1.5.0",
     "passport-local": "^1.0.0",
     "scmp": "^2.0.0",
@@ -29,6 +28,7 @@
     "chai": "^4.1.2",
     "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",
+    "debug": "^3.1.0",
     "drop-mongodb-collections": "^1.2.4",
     "eslint": "^5.3.0",
     "mocha": "^5.2.0",


### PR DESCRIPTION
Since debug are used in tests only we can put `debug` in devDependencies. With this it will be clear that `passport-local-mongoose` do not implement debug statements in package functionality.