### PR TITLE
chore: update login example dependencies

### DIFF
--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -38,11 +38,12 @@ passport.serializeUser(Account.serializeUser());
 passport.deserializeUser(Account.deserializeUser());
 
 // Connect mongoose
-mongoose.connect('mongodb://localhost/passport_local_mongoose_examples', function(err) {
+mongoose.connect('mongodb://localhost/passport_local_mongoose_examples', { useNewUrlParser: true }, function(err) {
   if (err) {
     console.log('Could not connect to mongodb on localhost. Ensure that you have mongodb running on localhost and mongodb accepts connections on standard ports!');
   }
 });
+mongoose.set('useCreateIndex', true);
 
 // Register routes
 app.use('/', require('./routes'));
@@ -77,6 +78,5 @@ app.use(function(err, req, res, next) {
     error: {}
   });
 });
-
 
 module.exports = app;

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -6,17 +6,17 @@
     "start": "node ./bin/www"
   },
   "dependencies": {
-    "body-parser": "~1.8.1",
+    "body-parser": "^1.19.0",
     "cookie-parser": "~1.3.3",
     "cookie-session": "^1.1.0",
     "debug": "~2.0.0",
-    "express": "~4.9.0",
+    "express": "^4.17.1",
     "jade": "~1.6.0",
-    "mongoose": "3.8.x",
-    "morgan": "~1.3.0",
-    "passport": "0.2.x",
+    "mongoose": "^5.6.4",
+    "morgan": "^1.9.1",
+    "passport": "^0.4.0",
     "passport-local": "1.0.x",
-    "passport-local-mongoose": "*",
-    "serve-favicon": "~2.1.3"
+    "passport-local-mongoose": "^5.0.1",
+    "serve-favicon": "^2.5.0"
   }
 }


### PR DESCRIPTION
old version of mongoose was causing errors while accessing a local mongodb install on macOS high sierra. specifically, attempting to authenticate caused this error:

```text
TypeError: user.authenticate is not a function
    at Promise.resolve.then.then (~/saintedlama/passport-local-mongoose/examples/login/node_modules/passport-local-mongoose/index.js:194:23)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```