### PR TITLE
Escape username for regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,8 @@ module.exports = function(schema, options) {
     const queryOrParameters = [];
     for (let i = 0; i < options.usernameQueryFields.length; i++) {
       const parameter = {};
-      parameter[options.usernameQueryFields[i]] = options.usernameCaseInsensitive ? new RegExp(`^${username}$`, 'i') : username;
+      const usernameEscaped = username.replace(/[~`!@#$%^&*()_\-+={}[\]|\\:;"'<>,.?/]/g, '\\$&');
+      parameter[options.usernameQueryFields[i]] = options.usernameCaseInsensitive ? new RegExp(`^${usernameEscaped}$`, 'i') : username;
       queryOrParameters.push(parameter);
     }
 

--- a/index.js
+++ b/index.js
@@ -267,12 +267,16 @@ module.exports = function(schema, options) {
       username = username.toLowerCase();
     }
 
+    // escape regex tokens
+    if (username !== undefined && options.usernameCaseInsensitive) {
+      username = username.replace(/[$^*()+\-=<>{}()[|\]:\\.?]/g, '\\$&');
+    }
+    
     // Add each username query field
     const queryOrParameters = [];
     for (let i = 0; i < options.usernameQueryFields.length; i++) {
       const parameter = {};
-      const usernameEscaped = username.replace(/[$^*()+\-=<>{}()[|\]:\\.?]/g, '\\$&');
-      parameter[options.usernameQueryFields[i]] = options.usernameCaseInsensitive ? new RegExp(`^${usernameEscaped}$`, 'i') : username;
+      parameter[options.usernameQueryFields[i]] = options.usernameCaseInsensitive ? new RegExp(`^${username}$`, 'i') : username;
       queryOrParameters.push(parameter);
     }
 

--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ module.exports = function(schema, options) {
 
     // escape regex tokens
     if (username !== undefined && options.usernameCaseInsensitive) {
-      username = username.replace(/[$^*()+\-=<>{}()[|\]:\\.?]/g, '\\$&');
+      username = username.replace(/[!#$()*+\-./:<=>?[\\\]^{|}]/g, '\\$&');
     }
     
     // Add each username query field

--- a/index.js
+++ b/index.js
@@ -271,7 +271,7 @@ module.exports = function(schema, options) {
     const queryOrParameters = [];
     for (let i = 0; i < options.usernameQueryFields.length; i++) {
       const parameter = {};
-      const usernameEscaped = username.replace(/[~`!@#$%^&*()_\-+={}[\]|\\:;"'<>,.?/]/g, '\\$&');
+      const usernameEscaped = username.replace(/[$^*()+\-=<>{}()[|\]:\\.?]/g, '\\$&');
       parameter[options.usernameQueryFields[i]] = options.usernameCaseInsensitive ? new RegExp(`^${usernameEscaped}$`, 'i') : username;
       queryOrParameters.push(parameter);
     }


### PR DESCRIPTION
Currently when the `usernameCaseInsensitive` option is enabled then username is queried using regex constructed from unescaped username value.

This is a bit problematic because username can often contain special characters - e.g. it can be `hello+world@example.com` email address.

When we construct regex from that value then it will treat plus sign as a regex quantifier rather than character match. Here's how it fails:

```
const username = 'hello+world@example.com';
new RegExp(`^${username}$`, 'i').test(username) // = false
```

And this leads to **inability to authenticate** using that email address after it was used for registration. It can also potentially lead to some **security/stability vulnerabilities**, like e.g. [ReDoS](https://en.wikipedia.org/wiki/ReDoS).

My solution here is to [escape regex token characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping) in username before that value gets put into RegExp constructor.