### PR TITLE
Add option to use raw salt during password hash generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ User.plugin(passportLocalMongoose, options);
 * usernameField: specifies the field name that holds the username. Defaults to 'username'. This option can be used if you want to use a different field to hold the username for example "email".
 * usernameUnique : specifies if the username field should be enforced to be unique by a mongodb index or not. Defaults to true.
 * saltField: specifies the field name that holds the salt value. Defaults to 'salt'.
+* rawSalt: specifies whether to send salt raw bytes during password hashing, or encoded salt using hex, or encoding specified in encoding option. Default: false.
 * hashField: specifies the field name that holds the password hash value. Defaults to 'hash'.
 * attemptsField: specifies the field name that holds the number of login failures since the last successful login. Defaults to 'attempts'.
 * lastLoginField: specifies the field name that holds the timestamp of the last login attempt. Defaults to 'last'.

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -39,7 +39,9 @@ function authenticate(user, password, options, cb) {
     return cb(null, false, new errors.NoSaltValueStoredError(options.errorMessages.NoSaltValueStoredError));
   }
 
-  pbkdf2(password, user.get(options.saltField), options, function(err, hashBuffer) {
+  var salt = user.get(options.saltField);
+  if (options.rawSalt) salt = Buffer.from(user.get(options.saltField), 'base64');
+  pbkdf2(password, salt, options, function(err, hashBuffer) {
     if (err) {
       return cb(err);
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "passport-local-mongoose",
   "description": "Mongoose plugin that simplifies building username and password login with Passport",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "main": "index.js",
   "repository": "saintedlama/passport-local-mongoose",
   "author": "Christoph Walcher <christoph.walcher@gmail.com>",


### PR DESCRIPTION
As-per #298, added ability to use raw salt:

    Add options.rawSalt, boolean
    Modify pbkdf2 call on setPassword to use raw salt, if options.rawSalt == true
    Modify pbkdf2 call on authenticate to use raw salt, if options.rawSalt == true
    Update readme with rawSalt option information

Note this is set to false by default as would be a breaking change for existing users.