### PR TITLE
fix: update README.md to show correct dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ to have these dependencies installed.
 In case you need to install the whole set of dependencies
 
 ```bash
-> npm install passport mongoose passport-local-mongoose
+> npm install passport passport-local mongoose passport-local-mongoose
 ```
 
 ## Usage


### PR DESCRIPTION
If you try to install passport-local-mongoose without passport-local it will not work and will get stuck. Added it to the dependency list in README.md.