### PR TITLE
chore: update mongoose

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,7 +295,10 @@ module.exports = function (schema, options) {
     }
 
     if (cb) {
-      query.exec(cb);
+      query
+        .exec()
+        .then((user) => cb(null, user))
+        .catch(cb);
       return;
     }
 

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -21,12 +21,14 @@ function authenticate(user, password, options, cb) {
 
     if (Date.now() - user.get(options.lastLoginField) < calculatedInterval) {
       user.set(options.lastLoginField, Date.now());
-      user.save(function (saveErr) {
-        if (saveErr) {
+      user
+        .save()
+        .then(function () {
+          return cb(null, false, new errors.AttemptTooSoonError(options.errorMessages.AttemptTooSoonError));
+        })
+        .catch(function (saveErr) {
           return cb(saveErr);
-        }
-        return cb(null, false, new errors.AttemptTooSoonError(options.errorMessages.AttemptTooSoonError));
-      });
+        });
       return;
     }
 
@@ -54,12 +56,14 @@ function authenticate(user, password, options, cb) {
       if (options.limitAttempts) {
         user.set(options.lastLoginField, Date.now());
         user.set(options.attemptsField, 0);
-        user.save(function (saveErr, user) {
-          if (saveErr) {
+        user
+          .save()
+          .then(function (user) {
+            return cb(null, user);
+          })
+          .catch(function (saveErr) {
             return cb(saveErr);
-          }
-          return cb(null, user);
-        });
+          });
       } else {
         return cb(null, user);
       }
@@ -67,16 +71,18 @@ function authenticate(user, password, options, cb) {
       if (options.limitAttempts) {
         user.set(options.lastLoginField, Date.now());
         user.set(options.attemptsField, user.get(options.attemptsField) + 1);
-        user.save(function (saveErr) {
-          if (saveErr) {
+        user
+          .save()
+          .then(function () {
+            if (user.get(options.attemptsField) >= options.maxAttempts) {
+              return cb(null, false, new errors.TooManyAttemptsError(options.errorMessages.TooManyAttemptsError));
+            } else {
+              return cb(null, false, new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError));
+            }
+          })
+          .catch(function (saveErr) {
             return cb(saveErr);
-          }
-          if (user.get(options.attemptsField) >= options.maxAttempts) {
-            return cb(null, false, new errors.TooManyAttemptsError(options.errorMessages.TooManyAttemptsError));
-          } else {
-            return cb(null, false, new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError));
-          }
-        });
+          });
       } else {
         return cb(null, false, new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError));
       }

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -15,6 +15,8 @@ module.exports = function (user, password, options, cb) {
 };
 
 function authenticate(user, password, options, cb) {
+  let promise = Promise.resolve();
+
   if (options.limitAttempts) {
     const attemptsInterval = Math.pow(options.interval, Math.log(user.get(options.attemptsField) + 1));
     const calculatedInterval = attemptsInterval < options.maxInterval ? attemptsInterval : options.maxInterval;
@@ -36,56 +38,59 @@ function authenticate(user, password, options, cb) {
       if (options.unlockInterval && Date.now() - user.get(options.lastLoginField) > options.unlockInterval) {
         user.set(options.lastLoginField, Date.now());
         user.set(options.attemptsField, 0);
-        user.save();
+
+        promise = user.save();
       } else {
         return cb(null, false, new errors.TooManyAttemptsError(options.errorMessages.TooManyAttemptsError));
       }
     }
   }
 
-  if (!user.get(options.saltField)) {
-    return cb(null, false, new errors.NoSaltValueStoredError(options.errorMessages.NoSaltValueStoredError));
-  }
-
-  pbkdf2(password, user.get(options.saltField), options, function (err, hashBuffer) {
-    if (err) {
-      return cb(err);
+  promise.then(function () {
+    if (!user.get(options.saltField)) {
+      return cb(null, false, new errors.NoSaltValueStoredError(options.errorMessages.NoSaltValueStoredError));
     }
 
-    if (scmp(hashBuffer, Buffer.from(user.get(options.hashField), options.encoding))) {
-      if (options.limitAttempts) {
-        user.set(options.lastLoginField, Date.now());
-        user.set(options.attemptsField, 0);
-        user
-          .save()
-          .then(function (user) {
-            return cb(null, user);
-          })
-          .catch(function (saveErr) {
-            return cb(saveErr);
-          });
-      } else {
-        return cb(null, user);
+    pbkdf2(password, user.get(options.saltField), options, function (err, hashBuffer) {
+      if (err) {
+        return cb(err);
       }
-    } else {
-      if (options.limitAttempts) {
-        user.set(options.lastLoginField, Date.now());
-        user.set(options.attemptsField, user.get(options.attemptsField) + 1);
-        user
-          .save()
-          .then(function () {
-            if (user.get(options.attemptsField) >= options.maxAttempts) {
-              return cb(null, false, new errors.TooManyAttemptsError(options.errorMessages.TooManyAttemptsError));
-            } else {
-              return cb(null, false, new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError));
-            }
-          })
-          .catch(function (saveErr) {
-            return cb(saveErr);
-          });
+
+      if (scmp(hashBuffer, Buffer.from(user.get(options.hashField), options.encoding))) {
+        if (options.limitAttempts) {
+          user.set(options.lastLoginField, Date.now());
+          user.set(options.attemptsField, 0);
+          user
+            .save()
+            .then(function (user) {
+              return cb(null, user);
+            })
+            .catch(function (saveErr) {
+              return cb(saveErr);
+            });
+        } else {
+          return cb(null, user);
+        }
       } else {
-        return cb(null, false, new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError));
+        if (options.limitAttempts) {
+          user.set(options.lastLoginField, Date.now());
+          user.set(options.attemptsField, user.get(options.attemptsField) + 1);
+          user
+            .save()
+            .then(function () {
+              if (user.get(options.attemptsField) >= options.maxAttempts) {
+                return cb(null, false, new errors.TooManyAttemptsError(options.errorMessages.TooManyAttemptsError));
+              } else {
+                return cb(null, false, new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError));
+              }
+            })
+            .catch(function (saveErr) {
+              return cb(saveErr);
+            });
+        } else {
+          return cb(null, false, new errors.IncorrectPasswordError(options.errorMessages.IncorrectPasswordError));
+        }
       }
-    }
+    });
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "mocha": "^10.0.0",
         "mocha-lcov-reporter": "^1.3.0",
-        "mongoose": "^6.3.4",
+        "mongoose": "^7.0.1",
         "nyc": "^15.1.0",
         "prettier": "^2.6.2",
         "should-release": "^1.2.0",
@@ -2722,9 +2722,9 @@
       "dev": true
     },
     "node_modules/ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
     "node_modules/irregular-plurals": {
@@ -3119,10 +3119,13 @@
       }
     },
     "node_modules/kareem": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.5.tgz",
-      "integrity": "sha512-qxCyQtp3ioawkiRNQr/v8xw9KIviMSSNmy+63Wubj7KmMn3g7noRXIZB4vPCAP+ETi2SR8eH6CvmlKZuGpoHOg==",
-      "dev": true
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -3746,9 +3749,9 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.2.tgz",
-      "integrity": "sha512-tWDyIG8cQlI5k3skB6ywaEA5F9f5OntrKKsT/Lteub2zgwSUlhqEN2inGgBTm8bpYJf8QYBdA/5naz65XDpczA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "dev": true,
       "dependencies": {
         "@types/whatwg-url": "^8.2.1",
@@ -3756,43 +3759,67 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.3.4.tgz",
-      "integrity": "sha512-UP0azyGMdY+2YNbJUHeHhnVw5vPzCqs4GQDUwHkilif/rwmSZktUQhQWMp1pUgRNeF2JC30vWGLrInZxD7K/Qw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.0.1.tgz",
+      "integrity": "sha512-fxm2bPRG457Hb8RLwN8cMCokK8HNem/7g+qp5SrHC7Pt4Z4jqn1+/3cuc8W7uqehKDWEtpirggI7uw08x2ZIjQ==",
       "dev": true,
       "dependencies": {
-        "bson": "^4.6.2",
-        "kareem": "2.3.5",
-        "mongodb": "4.5.0",
+        "bson": "^5.0.1",
+        "kareem": "2.5.1",
+        "mongodb": "5.1.0",
         "mpath": "0.9.0",
-        "mquery": "4.0.3",
+        "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.0"
+        "sift": "16.0.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose/node_modules/bson": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.1.tgz",
+      "integrity": "sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
     "node_modules/mongoose/node_modules/mongodb": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.5.0.tgz",
-      "integrity": "sha512-A2l8MjEpKojnhbCM0MK3+UOGUSGvTNNSv7AkP1fsT7tkambrkkqN/5F2y+PhzsV0Nbv58u04TETpkaSEdI2zKA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
+      "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
       "dev": true,
       "dependencies": {
-        "bson": "^4.6.2",
-        "denque": "^2.0.1",
-        "mongodb-connection-string-url": "^2.5.2",
-        "socks": "^2.6.2"
+        "bson": "^5.0.1",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=14.20.1"
       },
       "optionalDependencies": {
         "saslprep": "^1.0.3"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.201.0",
+        "mongodb-client-encryption": "^2.3.0",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongoose/node_modules/ms": {
@@ -3811,15 +3838,15 @@
       }
     },
     "node_modules/mquery": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
-      "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
       "dev": true,
       "dependencies": {
         "debug": "4.x"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -4897,9 +4924,9 @@
       }
     },
     "node_modules/sift": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
-      "integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
       "dev": true
     },
     "node_modules/signal-exit": {
@@ -4928,12 +4955,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dev": true,
       "dependencies": {
-        "ip": "^1.1.5",
+        "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -7932,9 +7959,9 @@
       "dev": true
     },
     "ip": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
     "irregular-plurals": {
@@ -8236,9 +8263,9 @@
       }
     },
     "kareem": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.5.tgz",
-      "integrity": "sha512-qxCyQtp3ioawkiRNQr/v8xw9KIviMSSNmy+63Wubj7KmMn3g7noRXIZB4vPCAP+ETi2SR8eH6CvmlKZuGpoHOg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
       "dev": true
     },
     "kind-of": {
@@ -8718,9 +8745,9 @@
       }
     },
     "mongodb-connection-string-url": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.2.tgz",
-      "integrity": "sha512-tWDyIG8cQlI5k3skB6ywaEA5F9f5OntrKKsT/Lteub2zgwSUlhqEN2inGgBTm8bpYJf8QYBdA/5naz65XDpczA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "dev": true,
       "requires": {
         "@types/whatwg-url": "^8.2.1",
@@ -8728,31 +8755,36 @@
       }
     },
     "mongoose": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.3.4.tgz",
-      "integrity": "sha512-UP0azyGMdY+2YNbJUHeHhnVw5vPzCqs4GQDUwHkilif/rwmSZktUQhQWMp1pUgRNeF2JC30vWGLrInZxD7K/Qw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.0.1.tgz",
+      "integrity": "sha512-fxm2bPRG457Hb8RLwN8cMCokK8HNem/7g+qp5SrHC7Pt4Z4jqn1+/3cuc8W7uqehKDWEtpirggI7uw08x2ZIjQ==",
       "dev": true,
       "requires": {
-        "bson": "^4.6.2",
-        "kareem": "2.3.5",
-        "mongodb": "4.5.0",
+        "bson": "^5.0.1",
+        "kareem": "2.5.1",
+        "mongodb": "5.1.0",
         "mpath": "0.9.0",
-        "mquery": "4.0.3",
+        "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.0"
+        "sift": "16.0.1"
       },
       "dependencies": {
+        "bson": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.1.tgz",
+          "integrity": "sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q==",
+          "dev": true
+        },
         "mongodb": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.5.0.tgz",
-          "integrity": "sha512-A2l8MjEpKojnhbCM0MK3+UOGUSGvTNNSv7AkP1fsT7tkambrkkqN/5F2y+PhzsV0Nbv58u04TETpkaSEdI2zKA==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
+          "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
           "dev": true,
           "requires": {
-            "bson": "^4.6.2",
-            "denque": "^2.0.1",
-            "mongodb-connection-string-url": "^2.5.2",
+            "bson": "^5.0.1",
+            "mongodb-connection-string-url": "^2.6.0",
             "saslprep": "^1.0.3",
-            "socks": "^2.6.2"
+            "socks": "^2.7.1"
           }
         },
         "ms": {
@@ -8770,9 +8802,9 @@
       "dev": true
     },
     "mquery": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.3.tgz",
-      "integrity": "sha512-J5heI+P08I6VJ2Ky3+33IpCdAvlYGTSUjwTPxkAr8i8EoduPMBX2OY/wa3IKZIQl7MU4SbFk8ndgSKyB/cl1zA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
       "dev": true,
       "requires": {
         "debug": "4.x"
@@ -9571,9 +9603,9 @@
       }
     },
     "sift": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.0.tgz",
-      "integrity": "sha512-ILTjdP2Mv9V1kIxWMXeMTIRbOBrqKc4JAXmFMnFq3fKeyQ2Qwa3Dw1ubcye3vR+Y6ofA0b9gNDr/y2t6eUeIzQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ==",
       "dev": true
     },
     "signal-exit": {
@@ -9595,12 +9627,12 @@
       "dev": true
     },
     "socks": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
-      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dev": true,
       "requires": {
-        "ip": "^1.1.5",
+        "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "mocha": "^10.0.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "mongoose": "^6.3.4",
+    "mongoose": "^7.0.1",
     "nyc": "^15.1.0",
     "prettier": "^2.6.2",
     "should-release": "^1.2.0",

--- a/test/alternative-query-field.js
+++ b/test/alternative-query-field.js
@@ -31,9 +31,7 @@ describe('alternative query field', function () {
 
     const email = 'hugo@test.org';
     const user = new User({ username: 'hugo', email: email });
-    user.save(function (err) {
-      expect(err).to.not.exist;
-
+    user.save().then(function () {
       User.findByUsername(email, function (err, user) {
         expect(err).to.not.exist;
         expect(user).to.exist;

--- a/test/issues.js
+++ b/test/issues.js
@@ -56,8 +56,7 @@ describe('issues', function () {
     UserSchema.plugin(passportLocalMongoose);
     const User = mongoose.model('ShouldNotThrowIfPasswordOrSaltAreNotStored_Issue_27', UserSchema);
 
-    User.create({ username: 'hugo', name: 'Hugo Wiener', age: 143 }, function (err, user) {
-      expect(err).to.not.exist;
+    User.create({ username: 'hugo', name: 'Hugo Wiener', age: 143 }).then(function (user) {
       expect(user).to.exist;
 
       User.authenticate()('hugo', 'none', function (err, auth, error) {
@@ -107,8 +106,7 @@ describe('issues', function () {
     const loginDate = new Date();
     const loginSuccess = true;
 
-    Login.create({ date: loginDate, success: loginSuccess }, function (err, login) {
-      expect(err).to.not.exist;
+    Login.create({ date: loginDate, success: loginSuccess }).then(function (login) {
       expect(login).to.exist;
 
       const logins = [];
@@ -183,8 +181,7 @@ describe('issues', function () {
     User.register({ username: 'nicolascage' }, 'password', function (err, user) {
       expect(err).to.not.exist;
       expect(user).to.exist;
-      User.findOne({ username: 'nicolascage' }, function (err, user) {
-        expect(err).to.not.exist;
+      User.findOne({ username: 'nicolascage' }).then(function (user) {
         expect(user).to.exist;
         expect(user.username).to.equal('nicolascage');
         expect(user.hash).to.equal(undefined);
@@ -208,8 +205,7 @@ describe('issues', function () {
     });
 
     it('instance.authenticate( password, callback )', function (done) {
-      User.findOne({ username: userName }, function (err, user) {
-        expect(err).to.not.exist;
+      User.findOne({ username: userName }).then(function (user) {
         expect(user).to.exist;
         expect(user.username).to.equal(userName);
         user.authenticate('password', function (err, auth) {
@@ -239,23 +235,18 @@ describe('issues', function () {
       const User = mongoose.model('AuthenticateBackwardCompatible', UserSchema);
 
       // 3.0 generated hash and salt of 'username', 'password'
-      User.create(
-        {
-          salt: 'fd4bb06e65cd4d582efde28427ffdeb8839c64169d72cfe131bd971f70dc08f8',
-          hash: '2ce573e406497fcbc2c1e91532cdbcf198ecbe2692cd5b3dffc303c51e6ccf56ae6a1ed9bac17f6f185d2d289ed713f7bd2a7a6246a4974495a35ff95bba234e00757d8a78fb28836a984c3e67465a019ead84d684896712c50f670663134685225b6832ec5a0a99922eabe6ba03abc1e79bc6a29ca2fe23456034eff2987277331f9e32713b3293ab355882feebe9c37ecdcd1a22dcebd6e5799adeb6a4dc32e56398d21ece6eda07b84944c3918de6bda69ab7998be461f98ff1559a07fd5d3100d732da443110b3ac7d27d16098c4e1eab7489f6d2a5849981a5c9f5dadb86d8dbbb9b60ce67304e21221e77d1a2700cab460450702c16b99db2e3b67454765fe9e4054c87a9e436fb17db1774b9d22a129c1b120dad0925b58390b8a02241e7e06acbe87dbe7f0e91b5d000cd93fc7cc8f316f45b901b8eb58ea6853c8e7ead245a9329239ed4f3797bc12a151ffedd8e8d2533547a1aec7231a460ca128ebfb1bd6b6f988455505c21d2dbfe01ee4b321a3d20a5bf6e2a356b6f4dbb8ddb4cff7dc9779b9747881af4d08e2fbcf452746e07275ed350fad0d4e6e8fcbedb0575c1413be5a913ca6ef4fcf17d1021b93fe2b3b410cf612791f967521ae558459673156e431be5203ca944e80652559eaf3faa90250df3d24526d5f9fc3409e508a3e2175daaf492fd6efd748e4418834b631f84fe266ac32f4927c3a426b',
-          username: 'username',
-        },
-        function (err) {
+      User.create({
+        salt: 'fd4bb06e65cd4d582efde28427ffdeb8839c64169d72cfe131bd971f70dc08f8',
+        hash: '2ce573e406497fcbc2c1e91532cdbcf198ecbe2692cd5b3dffc303c51e6ccf56ae6a1ed9bac17f6f185d2d289ed713f7bd2a7a6246a4974495a35ff95bba234e00757d8a78fb28836a984c3e67465a019ead84d684896712c50f670663134685225b6832ec5a0a99922eabe6ba03abc1e79bc6a29ca2fe23456034eff2987277331f9e32713b3293ab355882feebe9c37ecdcd1a22dcebd6e5799adeb6a4dc32e56398d21ece6eda07b84944c3918de6bda69ab7998be461f98ff1559a07fd5d3100d732da443110b3ac7d27d16098c4e1eab7489f6d2a5849981a5c9f5dadb86d8dbbb9b60ce67304e21221e77d1a2700cab460450702c16b99db2e3b67454765fe9e4054c87a9e436fb17db1774b9d22a129c1b120dad0925b58390b8a02241e7e06acbe87dbe7f0e91b5d000cd93fc7cc8f316f45b901b8eb58ea6853c8e7ead245a9329239ed4f3797bc12a151ffedd8e8d2533547a1aec7231a460ca128ebfb1bd6b6f988455505c21d2dbfe01ee4b321a3d20a5bf6e2a356b6f4dbb8ddb4cff7dc9779b9747881af4d08e2fbcf452746e07275ed350fad0d4e6e8fcbedb0575c1413be5a913ca6ef4fcf17d1021b93fe2b3b410cf612791f967521ae558459673156e431be5203ca944e80652559eaf3faa90250df3d24526d5f9fc3409e508a3e2175daaf492fd6efd748e4418834b631f84fe266ac32f4927c3a426b',
+        username: 'username',
+      }).then(function () {
+        User.authenticate()('username', 'password', function (err, authenticated) {
           expect(err).to.not.exist;
+          expect(authenticated).to.exist;
 
-          User.authenticate()('username', 'password', function (err, authenticated) {
-            expect(err).to.not.exist;
-            expect(authenticated).to.exist;
-
-            done();
-          });
-        }
-      );
+          done();
+        });
+      });
     });
   });
 

--- a/test/passport-local-mongoose.js
+++ b/test/passport-local-mongoose.js
@@ -434,20 +434,21 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
+        user
+          .save()
+          .then(function () {
+            user.authenticate('password', function (err, user, error) {
+              if (err) {
+                return done(err);
+              }
+              expect(user).to.be.false;
+              expect(error).to.be.instanceof(errors.AttemptTooSoonError);
+              done();
+            });
+          })
+          .catch(function (err) {
             return done(err);
-          }
-
-          user.authenticate('password', function (err, user, error) {
-            if (err) {
-              return done(err);
-            }
-            expect(user).to.be.false;
-            expect(error).to.be.instanceof(errors.AttemptTooSoonError);
-            done();
           });
-        });
       });
     });
 
@@ -469,18 +470,19 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
+        user
+          .save()
+          .then(function () {
+            user.authenticate('password', function (err, user, error) {
+              expect(err).to.not.exist;
+              expect(user).to.be.false;
+              expect(error).to.be.instanceOf(errors.AttemptTooSoonError);
+              done();
+            });
+          })
+          .catch(function (err) {
             return done(err);
-          }
-
-          user.authenticate('password', function (err, user, error) {
-            expect(err).to.not.exist;
-            expect(user).to.be.false;
-            expect(error).to.be.instanceOf(errors.AttemptTooSoonError);
-            done();
           });
-        });
       });
     });
 
@@ -499,22 +501,23 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
+        user
+          .save()
+          .then(function () {
+            user.authenticate('password', function (err, result, error) {
+              if (err) {
+                return done(err);
+              }
+
+              expect(result).to.exist;
+              expect(result.username).to.equal(user.username);
+              expect(error).to.not.exist;
+              done();
+            });
+          })
+          .catch(function (err) {
             return done(err);
-          }
-
-          user.authenticate('password', function (err, result, error) {
-            if (err) {
-              return done(err);
-            }
-
-            expect(result).to.exist;
-            expect(result.username).to.equal(user.username);
-            expect(error).to.not.exist;
-            done();
           });
-        });
       });
     });
 
@@ -536,20 +539,21 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
+        user
+          .save()
+          .then(function () {
+            user.authenticate('WRONGpassword', function (err, user, error) {
+              if (err) {
+                return done(err);
+              }
+              expect(user).to.be.false;
+              expect(error).to.be.instanceof(errors.AttemptTooSoonError);
+              done();
+            });
+          })
+          .catch(function (err) {
             return done(err);
-          }
-
-          user.authenticate('WRONGpassword', function (err, user, error) {
-            if (err) {
-              return done(err);
-            }
-            expect(user).to.be.false;
-            expect(error).to.be.instanceof(errors.AttemptTooSoonError);
-            done();
           });
-        });
       });
     });
 
@@ -711,25 +715,26 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
+        user
+          .save()
+          .then(function () {
+            DefaultUser.authenticate()('user', 'password', function (err, result) {
+              if (err) {
+                return done(err);
+              }
+
+              expect(result).to.be.instanceof(DefaultUser);
+              expect(result.username).to.equal(user.username);
+
+              expect(result.salt).to.equal(user.salt);
+              expect(result.hash).to.equal(user.hash);
+
+              done();
+            });
+          })
+          .catch(function (err) {
             return done(err);
-          }
-
-          DefaultUser.authenticate()('user', 'password', function (err, result) {
-            if (err) {
-              return done(err);
-            }
-
-            expect(result).to.be.instanceof(DefaultUser);
-            expect(result.username).to.equal(user.username);
-
-            expect(result.salt).to.equal(user.salt);
-            expect(result.hash).to.equal(user.hash);
-
-            done();
           });
-        });
       });
     });
 
@@ -818,21 +823,22 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
+        user
+          .save()
+          .then(function () {
+            DefaultUser.authenticate()('user', 'wrongpassword', function (err, result, error) {
+              if (err) {
+                return done(err);
+              }
+              expect(result).to.equal(false);
+              expect(error.message).to.exist;
+
+              done();
+            });
+          })
+          .catch(function (err) {
             return done(err);
-          }
-
-          DefaultUser.authenticate()('user', 'wrongpassword', function (err, result, error) {
-            if (err) {
-              return done(err);
-            }
-            expect(result).to.equal(false);
-            expect(error.message).to.exist;
-
-            done();
           });
-        });
       });
     });
 
@@ -848,17 +854,9 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
-            return done(err);
-          }
-
-          User.authenticate()('user', 'WRONGpassword', function (err, result) {
-            if (err) {
-              return done(err);
-            }
-            expect(result).to.be.false;
-
+        user
+          .save()
+          .then(function () {
             User.authenticate()('user', 'WRONGpassword', function (err, result) {
               if (err) {
                 return done(err);
@@ -871,19 +869,28 @@ describe('passportLocalMongoose', function () {
                 }
                 expect(result).to.be.false;
 
-                // Last login attempt should lock the user!
-                User.authenticate()('user', 'password', function (err, result) {
+                User.authenticate()('user', 'WRONGpassword', function (err, result) {
                   if (err) {
                     return done(err);
                   }
                   expect(result).to.be.false;
 
-                  done();
+                  // Last login attempt should lock the user!
+                  User.authenticate()('user', 'password', function (err, result) {
+                    if (err) {
+                      return done(err);
+                    }
+                    expect(result).to.be.false;
+
+                    done();
+                  });
                 });
               });
             });
+          })
+          .catch(function (err) {
+            return done(err);
           });
-        });
       });
     });
 
@@ -927,38 +934,39 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
-            return done(err);
-          }
-
-          authenticateWithWrongPassword(3, function () {
-            // Login attempt before should have locked the user!
-            User.authenticate()('user', 'password', function (err, result, data) {
-              if (err) {
-                return done(err);
-              }
-              expect(result).to.be.false;
-              expect(data.message).to.contain('locked');
-
-              user.resetAttempts(function (err) {
+        user
+          .save()
+          .then(function () {
+            authenticateWithWrongPassword(3, function () {
+              // Login attempt before should have locked the user!
+              User.authenticate()('user', 'password', function (err, result, data) {
                 if (err) {
                   return done(err);
                 }
+                expect(result).to.be.false;
+                expect(data.message).to.contain('locked');
 
-                // User should be unlocked
-                User.authenticate()('user', 'password', function (err, result) {
+                user.resetAttempts(function (err) {
                   if (err) {
                     return done(err);
                   }
-                  expect(result).to.exist;
 
-                  done();
+                  // User should be unlocked
+                  User.authenticate()('user', 'password', function (err, result) {
+                    if (err) {
+                      return done(err);
+                    }
+                    expect(result).to.exist;
+
+                    done();
+                  });
                 });
               });
             });
+          })
+          .catch(function (err) {
+            return done(err);
           });
-        });
       });
     });
 
@@ -1003,34 +1011,35 @@ describe('passportLocalMongoose', function () {
           return done(err);
         }
 
-        user.save(function (err) {
-          if (err) {
-            return done(err);
-          }
+        user
+          .save()
+          .then(function () {
+            authenticateWithWrongPassword(3, function () {
+              // After 1000ms user should be unlocked
+              User.authenticate()('user', 'password', function (err, result, data) {
+                if (err) {
+                  return done(err);
+                }
+                expect(result).to.be.false;
+                expect(data.message).to.contain('locked');
 
-          authenticateWithWrongPassword(3, function () {
-            // After 1000ms user should be unlocked
-            User.authenticate()('user', 'password', function (err, result, data) {
-              if (err) {
-                return done(err);
-              }
-              expect(result).to.be.false;
-              expect(data.message).to.contain('locked');
+                setTimeout(function () {
+                  User.authenticate()('user', 'password', function (err, result) {
+                    if (err) {
+                      return done(err);
+                    }
+                    expect(result).to.not.be.false;
+                    expect(result).to.exist;
 
-              setTimeout(function () {
-                User.authenticate()('user', 'password', function (err, result) {
-                  if (err) {
-                    return done(err);
-                  }
-                  expect(result).to.not.be.false;
-                  expect(result).to.exist;
-
-                  done();
-                });
-              }, 1000);
+                    done();
+                  });
+                }, 1000);
+              });
             });
+          })
+          .catch(function (err) {
+            return done(err);
           });
-        });
       });
     });
   });
@@ -1320,21 +1329,22 @@ describe('passportLocalMongoose', function () {
       const User = mongoose.model('FindByUsername', UserSchema);
 
       const user = new User({ username: 'hugo' });
-      user.save(function (err) {
-        if (err) {
+      user
+        .save()
+        .then(function () {
+          User.findByUsername('hugo', function (err, user) {
+            if (err) {
+              return done(err);
+            }
+            expect(user).to.exist;
+            expect('hugo').to.equal(user.username);
+
+            done();
+          });
+        })
+        .catch(function (err) {
           return done(err);
-        }
-
-        User.findByUsername('hugo', function (err, user) {
-          if (err) {
-            return done(err);
-          }
-          expect(user).to.exist;
-          expect('hugo').to.equal(user.username);
-
-          done();
         });
-      });
     });
 
     it('should return a query object when no callback is specified', function (done) {
@@ -1343,25 +1353,28 @@ describe('passportLocalMongoose', function () {
       const User = mongoose.model('FindByUsernameQueryObject', UserSchema);
 
       const user = new User({ username: 'hugo' });
-      user.save(function (err) {
-        if (err) {
+      user
+        .save()
+        .then(function () {
+          const query = User.findByUsername('hugo');
+
+          expect(query).to.exist;
+
+          query
+            .exec()
+            .then(function (user) {
+              expect(user).to.exist;
+              expect(user.username).to.equal('hugo');
+
+              done();
+            })
+            .catch(function (err) {
+              return done(err);
+            });
+        })
+        .catch(function (err) {
           return done(err);
-        }
-
-        const query = User.findByUsername('hugo');
-
-        expect(query).to.exist;
-
-        query.exec(function (err, user) {
-          if (err) {
-            return done(err);
-          }
-          expect(user).to.exist;
-          expect(user.username).to.equal('hugo');
-
-          done();
         });
-      });
     });
 
     it('should select all fields', function (done) {
@@ -1370,22 +1383,23 @@ describe('passportLocalMongoose', function () {
       const User = mongoose.model('FindByUsernameWithAllFields', UserSchema);
 
       const user = new User({ username: 'hugo', department: 'DevOps' });
-      user.save(function (err) {
-        if (err) {
+      user
+        .save()
+        .then(function () {
+          User.findByUsername('hugo', function (err, user) {
+            if (err) {
+              return done(err);
+            }
+            expect(user).to.exist;
+            expect(user.username).to.equal('hugo');
+            expect(user.department).to.equal('DevOps');
+
+            done();
+          });
+        })
+        .catch(function (err) {
           return done(err);
-        }
-
-        User.findByUsername('hugo', function (err, user) {
-          if (err) {
-            return done(err);
-          }
-          expect(user).to.exist;
-          expect(user.username).to.equal('hugo');
-          expect(user.department).to.equal('DevOps');
-
-          done();
         });
-      });
     });
 
     it('should select fields specified by selectFields option', function (done) {
@@ -1394,22 +1408,23 @@ describe('passportLocalMongoose', function () {
       const User = mongoose.model('FindByUsernameWithSelectFieldsOption', UserSchema);
 
       const user = new User({ username: 'hugo', department: 'DevOps' });
-      user.save(function (err) {
-        if (err) {
+      user
+        .save()
+        .then(function () {
+          User.findByUsername('hugo', function (err, user) {
+            if (err) {
+              return done(err);
+            }
+            expect(user).to.exist;
+            expect(user.username).to.equal('hugo');
+            expect(user.department).to.equal(undefined);
+
+            done();
+          });
+        })
+        .catch(function (err) {
           return done(err);
-        }
-
-        User.findByUsername('hugo', function (err, user) {
-          if (err) {
-            return done(err);
-          }
-          expect(user).to.exist;
-          expect(user.username).to.equal('hugo');
-          expect(user.department).to.equal(undefined);
-
-          done();
         });
-      });
     });
 
     it('should retrieve saved user with findByUsername helper function with username field override', function (done) {
@@ -1420,21 +1435,22 @@ describe('passportLocalMongoose', function () {
       const email = 'emailUsedForUsername';
       const user = new User({ email: email });
 
-      user.save(function (err) {
-        if (err) {
+      user
+        .save()
+        .then(function () {
+          User.findByUsername(email, function (err, user) {
+            if (err) {
+              return done(err);
+            }
+            expect(user).to.exist;
+            expect(email).to.equal(user.email);
+
+            done();
+          });
+        })
+        .catch(function (err) {
           return done(err);
-        }
-
-        User.findByUsername(email, function (err, user) {
-          if (err) {
-            return done(err);
-          }
-          expect(user).to.exist;
-          expect(email).to.equal(user.email);
-
-          done();
         });
-      });
     });
 
     it('should not throw if lowercase option is specified and no username is supplied', function (done) {
@@ -1654,28 +1670,30 @@ describe('passportLocalMongoose', function () {
       const User = mongoose.model('RegisterExistingUser', UserSchema);
 
       const existingUser = new User({});
-      existingUser.save(function (err, user) {
-        if (err) {
-          return done(err);
-        }
-        expect(user).to.exist;
-
-        user.username = 'hugo';
-        User.register(user, 'password', function (err, user) {
-          if (err) {
-            return done(err);
-          }
+      existingUser
+        .save()
+        .then(function (user) {
           expect(user).to.exist;
 
-          User.findByUsername('hugo', function (err, user) {
+          user.username = 'hugo';
+          User.register(user, 'password', function (err, user) {
             if (err) {
               return done(err);
             }
             expect(user).to.exist;
-            done();
+
+            User.findByUsername('hugo', function (err, user) {
+              if (err) {
+                return done(err);
+              }
+              expect(user).to.exist;
+              done();
+            });
           });
+        })
+        .catch(function (err) {
+          return done(err);
         });
-      });
     });
 
     it('should result in AuthenticationError error in case no username was given', function (done) {


### PR DESCRIPTION
This PR updates Mongoose to v7 where [callback support has been dropped](https://github.com/Automattic/mongoose/issues/11431). It should fix #369 with minimal changes:
- Replacing `Document.save(cb)` with `Document.save().then(document => cb(null, document)).catch(cb)`
- Replacing `Query.exec(cb)` with `Query.exec().then(document => cb(null, document)).catch(cb)`

Is this a reasonable approach or would you want to remove callback support from the plugin methods, too?