### PR TITLE
feat: add options for custom password hashing/verifying functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ User.plugin(passportLocalMongoose, options);
     ```
 * `usernameQueryFields`: specifies alternative fields of the model for identifying a user (e.g. email).
 * `findByUsername`: Specifies a query function that is executed with query parameters to restrict the query with extra query parameters. For example query only users with field "active" set to `true`. Default: `function(model, queryParameters) { return model.findOne(queryParameters); }`. See the examples section for a use case.
+* `generatePasswordHashAsync`: specifies a custom function for generating the password hash. Default: see `lib/pbkdfs.js`.
+* `verifyPasswordHashAsync`: specifies a custom function for verifying the password hash. Default: see `lib/pbkdfs.js`.
 
 **_Attention!_** Changing any of the hashing options (saltlen, iterations or keylen) in a production environment will prevent existing users from authenticating!
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,9 @@ declare module 'mongoose' {
       encoding?: string | undefined;
       digestAlgorithm?: string | undefined;
       passwordValidator?: ((password: string, cb: (err: any) => void) => void) | undefined;
+      verifyPasswordHashAsync: (password: string) => Promise<{ hash: string, salt: string }>;
+      generatePasswordHashAsync: (password: string, user: Document, options: PassportLocalOptions) => Promise<boolean>;
+
 
       usernameField?: string | undefined;
       usernameUnique?: boolean | undefined;

--- a/lib/authenticate.js
+++ b/lib/authenticate.js
@@ -1,6 +1,3 @@
-const scmp = require('scmp');
-
-const pbkdf2 = require('./pbkdf2');
 const errors = require('./errors');
 
 // authenticate function needs refactoring - to avoid bugs we wrapped a bit dirty
@@ -38,7 +35,6 @@ function authenticate(user, password, options, cb) {
       if (options.unlockInterval && Date.now() - user.get(options.lastLoginField) > options.unlockInterval) {
         user.set(options.lastLoginField, Date.now());
         user.set(options.attemptsField, 0);
-
         promise = user.save();
       } else {
         return cb(null, false, new errors.TooManyAttemptsError(options.errorMessages.TooManyAttemptsError));
@@ -51,12 +47,8 @@ function authenticate(user, password, options, cb) {
       return cb(null, false, new errors.NoSaltValueStoredError(options.errorMessages.NoSaltValueStoredError));
     }
 
-    pbkdf2(password, user.get(options.saltField), options, function (err, hashBuffer) {
-      if (err) {
-        return cb(err);
-      }
-
-      if (scmp(hashBuffer, Buffer.from(user.get(options.hashField), options.encoding))) {
+    options.verifyPasswordHashAsync(password, user, options).then((isCorrect) => {
+      if (isCorrect === true) {
         if (options.limitAttempts) {
           user.set(options.lastLoginField, Date.now());
           user.set(options.attemptsField, 0);

--- a/lib/pbkdf2.js
+++ b/lib/pbkdf2.js
@@ -1,5 +1,37 @@
 const crypto = require('crypto');
 
-module.exports = function pbkdf2(password, salt, options, callback) {
-  crypto.pbkdf2(password, salt, options.iterations, options.keylen, options.digestAlgorithm, callback);
+const defaultPasswordHashGeneratorAsync = async (password, options) => {
+  const saltBuffer = await new Promise((resolve, reject) =>
+    crypto.randomBytes(options.saltlen, (err, saltBuffer) => (err ? reject(err) : resolve(saltBuffer)))
+  );
+
+  const salt = saltBuffer.toString(options.encoding);
+
+  const hashBuffer = await new Promise((resolve, reject) =>
+    crypto.pbkdf2(password, salt, options.iterations, options.keylen, options.digestAlgorithm, (err, hashBuffer) =>
+      err ? reject(err) : resolve(hashBuffer)
+    )
+  );
+
+  const hash = Buffer.from(hashBuffer, 'binary').toString(options.encoding);
+
+  return { hash, salt };
+};
+
+const defaultPasswordHashVerifierAsync = async (password, user, options) => {
+  const userHash = user.get(options.hashField);
+  const userSalt = user.get(options.saltField);
+
+  const hashBuffer = await new Promise((resolve, reject) =>
+    crypto.pbkdf2(password, userSalt, options.iterations, options.keylen, options.digestAlgorithm, (err, hashBuffer) =>
+      err ? reject(err) : resolve(hashBuffer)
+    )
+  );
+
+  return crypto.timingSafeEqual(Buffer.from(userHash, options.encoding), hashBuffer);
+};
+
+module.exports = {
+  defaultPasswordHashGeneratorAsync,
+  defaultPasswordHashVerifierAsync,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "generaterr": "^1.5.0",
-        "passport-local": "^1.0.0",
-        "scmp": "^2.1.0"
+        "passport-local": "^1.0.0"
       },
       "devDependencies": {
         "@types/passport": "1.0.7",
@@ -4818,11 +4817,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/scmp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
-      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q=="
-    },
     "node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -9518,11 +9512,6 @@
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
-    },
-    "scmp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
-      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q=="
     },
     "semver": {
       "version": "7.3.5",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "dependencies": {
     "generaterr": "^1.5.0",
-    "passport-local": "^1.0.0",
-    "scmp": "^2.1.0"
+    "passport-local": "^1.0.0"
   },
   "devDependencies": {
     "@types/passport": "1.0.7",


### PR DESCRIPTION
Hi, this PR proposes to move the hash generation and verification to separate functions and allow them to be overridden by the users via the new options `generatePasswordHashAsync` and `verifyPasswordHashAsync`. This makes it possible to use alternative hash functions (e.g., argon2), while the default behaviour is not changed and backwards-compatible. I also removed the "scmp" package and replaced it with the native `crypto.timingSafeEqual` function.

Please let me know the chances of this change being merged, I am happy to address any code reviews or feedback!

This should fix issues like #271, #298